### PR TITLE
CPLP-1576: Fix notifications naming

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -316,7 +316,7 @@ jobs:
           zip -r portal-backend-notification.zip
           src/notifications/Notifications.Service/.publish
           -x
-          src/notification/Notification.Service/.publish/Org.Eclipse.TractusX.Portal.Backend.Notification.Service
+          src/notifications/Notifications.Service/.publish/Org.Eclipse.TractusX.Portal.Backend.Notifications.Service
 
       - name: Run Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.1
@@ -329,7 +329,7 @@ jobs:
           filepath: "portal-backend-notification.zip"
           vid: "${{ secrets.ORG_VERACODE_API_ID }}"
           vkey: "${{ secrets.ORG_VERACODE_API_KEY }}"
-          include: 'Org.Eclipse.TractusX.Portal.Backend.Notification.Service.dll, Org.Eclipse.TractusX.Portal.Backend.Framework.Models.dll'
+          include: 'Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.dll, Org.Eclipse.TractusX.Portal.Backend.Framework.Models.dll'
 
   analyze-services-service:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile-notification-service
+++ b/docker/Dockerfile-notification-service
@@ -16,4 +16,4 @@ ENV ASPNETCORE_URLS http://+:8080
 EXPOSE 8080
 RUN chown -R 1000:3000 /app
 USER 1000:3000
-ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.Portal.Backend.Notification.Service.dll"]
+ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.Portal.Backend.Notifications.Service.dll"]


### PR DESCRIPTION
I noticed that I didn't resolve the conflicts correctly for the notifications package in the dockerfile and veracode workflow when moving v0.9.0 from catenax-ng/product-portal-backend to the fork: https://github.com/catenax-ng/tx-portal-backend/pull/2
https://jira.catena-x.net/browse/CPLP-1576