### PR TITLE
CPLP-1923 ensure provisioning-db connectionstring is not empty

### DIFF
--- a/src/provisioning/Provisioning.Library/ProvisioningManagerStartupServiceExtensions.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManagerStartupServiceExtensions.cs
@@ -39,7 +39,7 @@ public static class ProvisioningManagerStartupServiceExtensions
             .AddTransient<IServiceAccountCreation, ServiceAccountCreation>();
 
         var connectionString = configuration.GetConnectionString("ProvisioningDB");
-        if (connectionString != null)
+        if (!string.IsNullOrWhiteSpace(connectionString))
         {
             services.AddTransient<IProvisioningDBAccess, ProvisioningDBAccess>()
                 .AddDbContext<ProvisioningDBContext>(options =>


### PR DESCRIPTION
implements fix for https://jira.catena-x.net/browse/CPLP-1923

as the configuration of ProvisioningDB is currently dynamic and serviceCollection.AddDbContext<ProvisioningDBContext>(options => options.UseNpgsql(connectionString)) would not validate the options at startup but when ProvisioningDBContext is actually created for the first time it's important the validation that takes place at startup is consistent with that that happens at runtime.
Without this change a whilespace-only connection-string results in container starting up fine but any request to an endpoint would trigger initial creation of dbcontext which fails as this dbcontext-creation validates connectionstring not being empty or whitespace.
The change does not validate that the connectionstring is actually valid. A a result the execution of an endpoint that depends on a working connection to provisioning-db would fail on runtime. Other endpoints not depending on provisioning-db would still work.