### PR TITLE
Don't run veracode with every push in main

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -19,10 +19,8 @@
 name: "Veracode"
 
 on:
-  push:
-    branches: [main]
   #  push:
-  #    branches: [ feature/CPLP-1134-db-notification ]
+  #    branches: [main]
   # pull_request:
   # The branches below must be a subset of the branches above
   # branches: [ main ]


### PR DESCRIPTION
To run veracode with every push in main was added in the course of https://github.com/catenax-ng/tx-portal-backend/pull/13
This is inconvenient for the portal backend repo.