### PR TITLE
chore: update header template and year in headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,8 @@
             "commentbegin<!->": "<!--",
             "commentend<!->": "-->",
             "commentprefix<!->": "-",
-            "cx_header_default_bmw":[
-                "* Copyright (c) 2021,2023 BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_default":[
+                "* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -29,9 +28,8 @@
                 " *",
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
-            "cx_header_with_#_bmw":[
-                "Copyright (c) 2021,2023 BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_with_#":[
+                "Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -48,9 +46,8 @@
                 "",
                 " SPDX-License-Identifier: Apache-2.0"
             ],
-            "cx_header_with_<!->_bmw":[
-                "Copyright (c) 2021,2023 BMW Group AG",
-                "- Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_with_<!->":[
+                "Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 "-",
                 "- See the NOTICE file(s) distributed with this work for additional",
                 "- information regarding copyright ownership.",
@@ -66,120 +63,24 @@
                 "- under the License.",
                 "-",
                 "- SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_default_mercedes":[
-                "* Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                " *",
-                " * See the NOTICE file(s) distributed with this work for additional",
-                " * information regarding copyright ownership.",
-                " *",
-                " * This program and the accompanying materials are made available under the",
-                " * terms of the Apache License, Version 2.0 which is available at",
-                " * https://www.apache.org/licenses/LICENSE-2.0.",
-                " *",
-                " * Unless required by applicable law or agreed to in writing, software",
-                " * distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " * License for the specific language governing permissions and limitations",
-                " * under the License.",
-                " *",
-                " * SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_with_#_mercedes":[
-                "Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                "",
-                " See the NOTICE file(s) distributed with this work for additional",
-                " information regarding copyright ownership.",
-                "",
-                " This program and the accompanying materials are made available under the",
-                " terms of the Apache License, Version 2.0 which is available at",
-                " https://www.apache.org/licenses/LICENSE-2.0.",
-                "",
-                " Unless required by applicable law or agreed to in writing, software",
-                " distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " License for the specific language governing permissions and limitations",
-                " under the License.",
-                "",
-                " SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_default_tsystems":[
-                "* Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                " *",
-                " * See the NOTICE file(s) distributed with this work for additional",
-                " * information regarding copyright ownership.",
-                " *",
-                " * This program and the accompanying materials are made available under the",
-                " * terms of the Apache License, Version 2.0 which is available at",
-                " * https://www.apache.org/licenses/LICENSE-2.0.",
-                " *",
-                " * Unless required by applicable law or agreed to in writing, software",
-                " * distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " * License for the specific language governing permissions and limitations",
-                " * under the License.",
-                " *",
-                " * SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_with_#_tsystems":[
-                "Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                "",
-                " See the NOTICE file(s) distributed with this work for additional",
-                " information regarding copyright ownership.",
-                "",
-                " This program and the accompanying materials are made available under the",
-                " terms of the Apache License, Version 2.0 which is available at",
-                " https://www.apache.org/licenses/LICENSE-2.0.",
-                "",
-                " Unless required by applicable law or agreed to in writing, software",
-                " distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " License for the specific language governing permissions and limitations",
-                " under the License.",
-                "",
-                " SPDX-License-Identifier: Apache-2.0"
-            ],
+            ]
         }
     },
     "fileHeaderComment.template": {
-        "cx_header_default_bmw":[
+        "cx_header_default":[
             "${commentbegin}",
-            "${commentprefix} ${cx_header_default_bmw}",
+            "${commentprefix} ${cx_header_default}",
             "${commentend}"
         ],
-        "cx_header_with_<!->_bmw":[
+        "cx_header_with_<!->":[
             "${commentbegin<!->}",
-            "${commentprefix<!->} ${cx_header_with_<!->_bmw}",
+            "${commentprefix<!->} ${cx_header_with_<!->}",
             "${commentend<!->}"
         ],
-        "cx_header_with_#_bmw":[
+        "cx_header_with_#":[
             "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_bmw}",
-            "${commentend#}"
-        ],
-        "cx_header_default_mercedes":[
-            "${commentbegin}",
-            "${commentprefix} ${cx_header_default_mercedes}",
-            "${commentend}"
-        ],
-        "cx_header_with_#_mercedes":[
-            "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_mercedes}",
-            "${commentend#}"
-        ],
-        "cx_header_default_tsystems":[
-            "${commentbegin}",
-            "${commentprefix} ${cx_header_default_tsystems}",
-            "${commentend}"
-        ],
-        "cx_header_with_#_tsystems":[
-            "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_tsystems}",
+            "${commentprefix#} ${cx_header_with_#}",
             "${commentend#}"
         ]
-    },
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,8 +11,8 @@
             "commentend<!->": "-->",
             "commentprefix<!->": "-",
             "cx_header_default_bmw":[
-                "* Copyright (c) 2021,2022 BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -30,8 +30,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_bmw":[
-                "Copyright (c) 2021,2022 BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -49,8 +49,8 @@
                 " SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_<!->_bmw":[
-                "Copyright (c) 2021,2022 BMW Group AG",
-                "- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 BMW Group AG",
+                "- Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "-",
                 "- See the NOTICE file(s) distributed with this work for additional",
                 "- information regarding copyright ownership.",
@@ -68,8 +68,8 @@
                 "- SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_default_mercedes":[
-                "* Copyright (c) 2021,2022 Mercedes-Benz Group AG and BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -87,8 +87,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_mercedes":[
-                "Copyright (c) 2021,2022 Mercedes-Benz Group AG and BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -106,8 +106,8 @@
                 " SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_default_tsystems":[
-                "* Copyright (c) 2021,2022 T-Systems International GmbH and BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -125,8 +125,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_tsystems":[
-                "Copyright (c) 2021,2022 T-Systems International GmbH and BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",

--- a/import/02-init-db.sql
+++ b/import/02-init-db.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+-- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 --
 -- See the NOTICE file(s) distributed with this work for additional
 -- information regarding copyright ownership.

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -10,9 +10,8 @@
             "commentbegin<!->": "<!--",
             "commentend<!->": "-->",
             "commentprefix<!->": "-",
-            "cx_header_default_bmw":[
-                "* Copyright (c) 2021,2023 BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_default":[
+                "* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -29,9 +28,8 @@
                 " *",
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
-            "cx_header_with_#_bmw":[
-                "Copyright (c) 2021,2023 BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_with_#":[
+                "Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -48,9 +46,8 @@
                 "",
                 " SPDX-License-Identifier: Apache-2.0"
             ],
-            "cx_header_with_<!->_bmw":[
-                "Copyright (c) 2021,2023 BMW Group AG",
-                "- Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
+            "cx_header_with_<!->":[
+                "Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation",
                 "-",
                 "- See the NOTICE file(s) distributed with this work for additional",
                 "- information regarding copyright ownership.",
@@ -66,120 +63,24 @@
                 "- under the License.",
                 "-",
                 "- SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_default_mercedes":[
-                "* Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                " *",
-                " * See the NOTICE file(s) distributed with this work for additional",
-                " * information regarding copyright ownership.",
-                " *",
-                " * This program and the accompanying materials are made available under the",
-                " * terms of the Apache License, Version 2.0 which is available at",
-                " * https://www.apache.org/licenses/LICENSE-2.0.",
-                " *",
-                " * Unless required by applicable law or agreed to in writing, software",
-                " * distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " * License for the specific language governing permissions and limitations",
-                " * under the License.",
-                " *",
-                " * SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_with_#_mercedes":[
-                "Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                "",
-                " See the NOTICE file(s) distributed with this work for additional",
-                " information regarding copyright ownership.",
-                "",
-                " This program and the accompanying materials are made available under the",
-                " terms of the Apache License, Version 2.0 which is available at",
-                " https://www.apache.org/licenses/LICENSE-2.0.",
-                "",
-                " Unless required by applicable law or agreed to in writing, software",
-                " distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " License for the specific language governing permissions and limitations",
-                " under the License.",
-                "",
-                " SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_default_tsystems":[
-                "* Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
-                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                " *",
-                " * See the NOTICE file(s) distributed with this work for additional",
-                " * information regarding copyright ownership.",
-                " *",
-                " * This program and the accompanying materials are made available under the",
-                " * terms of the Apache License, Version 2.0 which is available at",
-                " * https://www.apache.org/licenses/LICENSE-2.0.",
-                " *",
-                " * Unless required by applicable law or agreed to in writing, software",
-                " * distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " * License for the specific language governing permissions and limitations",
-                " * under the License.",
-                " *",
-                " * SPDX-License-Identifier: Apache-2.0"
-            ],
-            "cx_header_with_#_tsystems":[
-                "Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
-                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
-                "",
-                " See the NOTICE file(s) distributed with this work for additional",
-                " information regarding copyright ownership.",
-                "",
-                " This program and the accompanying materials are made available under the",
-                " terms of the Apache License, Version 2.0 which is available at",
-                " https://www.apache.org/licenses/LICENSE-2.0.",
-                "",
-                " Unless required by applicable law or agreed to in writing, software",
-                " distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT",
-                " WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the",
-                " License for the specific language governing permissions and limitations",
-                " under the License.",
-                "",
-                " SPDX-License-Identifier: Apache-2.0"
-            ],
+            ]
         }
     },
     "fileHeaderComment.template": {
-        "cx_header_default_bmw":[
+        "cx_header_default":[
             "${commentbegin}",
-            "${commentprefix} ${cx_header_default_bmw}",
+            "${commentprefix} ${cx_header_default}",
             "${commentend}"
         ],
-        "cx_header_with_<!->_bmw":[
+        "cx_header_with_<!->":[
             "${commentbegin<!->}",
-            "${commentprefix<!->} ${cx_header_with_<!->_bmw}",
+            "${commentprefix<!->} ${cx_header_with_<!->}",
             "${commentend<!->}"
         ],
-        "cx_header_with_#_bmw":[
+        "cx_header_with_#":[
             "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_bmw}",
-            "${commentend#}"
-        ],
-        "cx_header_default_mercedes":[
-            "${commentbegin}",
-            "${commentprefix} ${cx_header_default_mercedes}",
-            "${commentend}"
-        ],
-        "cx_header_with_#_mercedes":[
-            "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_mercedes}",
-            "${commentend#}"
-        ],
-        "cx_header_default_tsystems":[
-            "${commentbegin}",
-            "${commentprefix} ${cx_header_default_tsystems}",
-            "${commentend}"
-        ],
-        "cx_header_with_#_tsystems":[
-            "${commentbegin#}",
-            "${commentprefix#} ${cx_header_with_#_tsystems}",
+            "${commentprefix#} ${cx_header_with_#}",
             "${commentend#}"
         ]
-    },
+    }
 }

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -11,8 +11,8 @@
             "commentend<!->": "-->",
             "commentprefix<!->": "-",
             "cx_header_default_bmw":[
-                "* Copyright (c) 2021,2022 BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -30,8 +30,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_bmw":[
-                "Copyright (c) 2021,2022 BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -49,8 +49,8 @@
                 " SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_<!->_bmw":[
-                "Copyright (c) 2021,2022 BMW Group AG",
-                "- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 BMW Group AG",
+                "- Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "-",
                 "- See the NOTICE file(s) distributed with this work for additional",
                 "- information regarding copyright ownership.",
@@ -68,8 +68,8 @@
                 "- SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_default_mercedes":[
-                "* Copyright (c) 2021,2022 Mercedes-Benz Group AG and BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -87,8 +87,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_mercedes":[
-                "Copyright (c) 2021,2022 Mercedes-Benz Group AG and BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 Mercedes-Benz Group AG and BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",
@@ -106,8 +106,8 @@
                 " SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_default_tsystems":[
-                "* Copyright (c) 2021,2022 T-Systems International GmbH and BMW Group AG",
-                " * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "* Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
+                " * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 " *",
                 " * See the NOTICE file(s) distributed with this work for additional",
                 " * information regarding copyright ownership.",
@@ -125,8 +125,8 @@
                 " * SPDX-License-Identifier: Apache-2.0"
             ],
             "cx_header_with_#_tsystems":[
-                "Copyright (c) 2021,2022 T-Systems International GmbH and BMW Group AG",
-                " Copyright (c) 2021,2022 Contributors to the Eclipse Foundation",
+                "Copyright (c) 2021,2023 T-Systems International GmbH and BMW Group AG",
+                " Copyright (c) 2021,2023 Contributors to the Eclipse Foundation",
                 "",
                 " See the NOTICE file(s) distributed with this work for additional",
                 " information regarding copyright ownership.",

--- a/src/administration/Administration.Service/Administration.Service.csproj
+++ b/src/administration/Administration.Service/Administration.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/CompanyDataBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ConnectorsSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/DapsService.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DapsService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/DapsServiceCollectionExtension.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DapsServiceCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/DapsSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DapsSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/DocumentSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DocumentSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/DocumentsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/DocumentsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ICompanyDataBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IConnectorsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IDapsService.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IDapsService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IDocumentsBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IDocumentsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IIdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IIdentityProviderBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IInvitationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IPartnerNetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IPartnerNetworkBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceAccountBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IServiceProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IServiceProviderBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IStaticDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IStaticDataBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IUserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IUserBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IUserRolesBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IUserRolesBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IUserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IUserUploadBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IdentityProviderBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/IdentityProviderSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/IdentityProviderSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/InvitationSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/InvitationSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/PartnerNetworkBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/PartnerNetworkBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/RegistrationSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceAccountSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/ServiceProviderBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/ServiceProviderBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/StaticDataBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/StaticDataBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/UserRolesBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserRolesBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/UserSettings.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
+++ b/src/administration/Administration.Service/BusinessLogic/UserUploadBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/CompanyDataController.cs
+++ b/src/administration/Administration.Service/Controllers/CompanyDataController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/ConnectorsController.cs
+++ b/src/administration/Administration.Service/Controllers/ConnectorsController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/DocumentsController.cs
+++ b/src/administration/Administration.Service/Controllers/DocumentsController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/IdentityProviderController.cs
+++ b/src/administration/Administration.Service/Controllers/IdentityProviderController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/InvitationController.cs
+++ b/src/administration/Administration.Service/Controllers/InvitationController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/PartnerNetworkController.cs
+++ b/src/administration/Administration.Service/Controllers/PartnerNetworkController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/RegistrationController.cs
+++ b/src/administration/Administration.Service/Controllers/RegistrationController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
+++ b/src/administration/Administration.Service/Controllers/ServiceAccountController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/StaticDataController.cs
+++ b/src/administration/Administration.Service/Controllers/StaticDataController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Controllers/UserController.cs
+++ b/src/administration/Administration.Service/Controllers/UserController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/CompanyApplicationDetails.cs
+++ b/src/administration/Administration.Service/Models/CompanyApplicationDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/CompanyInvitationData.cs
+++ b/src/administration/Administration.Service/Models/CompanyInvitationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
+++ b/src/administration/Administration.Service/Models/CompanyWithAddressData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the CatenaX (ng) GitHub Organisation.
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the CatenaX (ng) GitHub Organisation.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/ConnectorEndPointData.cs
+++ b/src/administration/Administration.Service/Models/ConnectorEndPointData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/ConnectorInputModel.cs
+++ b/src/administration/Administration.Service/Models/ConnectorInputModel.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/IdentityProviderDetails.cs
+++ b/src/administration/Administration.Service/Models/IdentityProviderDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/IdentityProviderEditableDetails.cs
+++ b/src/administration/Administration.Service/Models/IdentityProviderEditableDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/IdentityProviderUpdateStats.cs
+++ b/src/administration/Administration.Service/Models/IdentityProviderUpdateStats.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/OwnCompanyUserEditableDetails.cs
+++ b/src/administration/Administration.Service/Models/OwnCompanyUserEditableDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/RegistrationDeclineData.cs
+++ b/src/administration/Administration.Service/Models/RegistrationDeclineData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/ServiceAccountDetails.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/ServiceAccountEditableDetails.cs
+++ b/src/administration/Administration.Service/Models/ServiceAccountEditableDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserCreationInfoIdp.cs
+++ b/src/administration/Administration.Service/Models/UserCreationInfoIdp.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserCreationStats.cs
+++ b/src/administration/Administration.Service/Models/UserCreationStats.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserIdentityProviderData.cs
+++ b/src/administration/Administration.Service/Models/UserIdentityProviderData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserRoleInfo.cs
+++ b/src/administration/Administration.Service/Models/UserRoleInfo.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserRoleMessage.cs
+++ b/src/administration/Administration.Service/Models/UserRoleMessage.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserUpdateBpn.cs
+++ b/src/administration/Administration.Service/Models/UserUpdateBpn.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/UserUpdateInfo.cs
+++ b/src/administration/Administration.Service/Models/UserUpdateInfo.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Models/WelcomeData.cs
+++ b/src/administration/Administration.Service/Models/WelcomeData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/administration/Administration.Service/Program.cs
+++ b/src/administration/Administration.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/Checklist.Library.csproj
+++ b/src/checklist/Checklist.Library/Checklist.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/ChecklistCreationService.cs
+++ b/src/checklist/Checklist.Library/ChecklistCreationService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/ChecklistService.cs
+++ b/src/checklist/Checklist.Library/ChecklistService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/DependencyInjection/ChecklistExtensions.cs
+++ b/src/checklist/Checklist.Library/DependencyInjection/ChecklistExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/IChecklistCreationService.cs
+++ b/src/checklist/Checklist.Library/IChecklistCreationService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Library/IChecklistService.cs
+++ b/src/checklist/Checklist.Library/IChecklistService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Worker/Checklist.Worker.csproj
+++ b/src/checklist/Checklist.Worker/Checklist.Worker.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/checklist/Checklist.Worker/ChecklistExecutionService.cs
+++ b/src/checklist/Checklist.Worker/ChecklistExecutionService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/checklist/Checklist.Worker/Program.cs
+++ b/src/checklist/Checklist.Worker/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/Bpdm.Library.csproj
+++ b/src/externalsystems/Bpdm.Library/Bpdm.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/BpdmService.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/BpdmServiceCollectionExtension.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmServiceCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
+++ b/src/externalsystems/Bpdm.Library/BpdmServiceSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
+++ b/src/externalsystems/Bpdm.Library/BusinessLogic/BpdmBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/BusinessLogic/IBpdmBusinessLogic.cs
+++ b/src/externalsystems/Bpdm.Library/BusinessLogic/IBpdmBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/IBpdmService.cs
+++ b/src/externalsystems/Bpdm.Library/IBpdmService.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmLegalEntityData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Bpdm.Library/Models/BpdmTransferData.cs
+++ b/src/externalsystems/Bpdm.Library/Models/BpdmTransferData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/ClearinghouseBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/BusinessLogic/IClearinghouseBusinessLogic.cs
+++ b/src/externalsystems/Clearinghouse.Library/BusinessLogic/IClearinghouseBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/Clearinghouse.Library.csproj
+++ b/src/externalsystems/Clearinghouse.Library/Clearinghouse.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/ClearinghouseService.cs
+++ b/src/externalsystems/Clearinghouse.Library/ClearinghouseService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/ClearinghouseServiceCollectionExtension.cs
+++ b/src/externalsystems/Clearinghouse.Library/ClearinghouseServiceCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/ClearinghouseSettings.cs
+++ b/src/externalsystems/Clearinghouse.Library/ClearinghouseSettings.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/IClearinghouseService.cs
+++ b/src/externalsystems/Clearinghouse.Library/IClearinghouseService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseResponseData.cs
+++ b/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseResponseData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseResponseStatus.cs
+++ b/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseResponseStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseTransferData.cs
+++ b/src/externalsystems/Clearinghouse.Library/Models/ClearinghouseTransferData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/BusinessLogic/CustodianBusinessLogic.cs
+++ b/src/externalsystems/Custodian.Library/BusinessLogic/CustodianBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/BusinessLogic/ICustodianBusinessLogic.cs
+++ b/src/externalsystems/Custodian.Library/BusinessLogic/ICustodianBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/Custodian.Library.csproj
+++ b/src/externalsystems/Custodian.Library/Custodian.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/CustodianService.cs
+++ b/src/externalsystems/Custodian.Library/CustodianService.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/CustodianServiceCollectionExtension.cs
+++ b/src/externalsystems/Custodian.Library/CustodianServiceCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/CustodianSettings.cs
+++ b/src/externalsystems/Custodian.Library/CustodianSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/ICustodianService.cs
+++ b/src/externalsystems/Custodian.Library/ICustodianService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/Custodian.Library/Models/WalletListItem.cs
+++ b/src/externalsystems/Custodian.Library/Models/WalletListItem.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/ISdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/ISdFactoryBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
+++ b/src/externalsystems/SdFactory.Library/BusinessLogic/SdFactoryBusinessLogic.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/Extensions/UniqueIdentifiersExtensions.cs
+++ b/src/externalsystems/SdFactory.Library/Extensions/UniqueIdentifiersExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/ISdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/ISdFactoryService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
+++ b/src/externalsystems/SdFactory.Library/Models/SdFactoryRequestModel.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/SdFactory.Library.csproj
+++ b/src/externalsystems/SdFactory.Library/SdFactory.Library.csproj
@@ -1,6 +1,6 @@
 ﻿<!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/SdFactoryService.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactoryService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
+++ b/src/externalsystems/SdFactory.Library/SdFactorySettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/externalsystems/SdFactory.Library/SdServiceCollectionExtension.cs
+++ b/src/externalsystems/SdFactory.Library/SdServiceCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Async/AsyncGroupByExtensions.cs
+++ b/src/framework/Framework.Async/AsyncGroupByExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Async/Framework.Async.csproj
+++ b/src/framework/Framework.Async/Framework.Async.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Async/ThrowingIAsyncEnumerableExtension.cs
+++ b/src/framework/Framework.Async/ThrowingIAsyncEnumerableExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.BaseDependencies/Framework.BaseDependencies.csproj
+++ b/src/framework/Framework.BaseDependencies/Framework.BaseDependencies.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Cors/CorsConfiguration.cs
+++ b/src/framework/Framework.Cors/CorsConfiguration.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Cors/CorsExtensions.cs
+++ b/src/framework/Framework.Cors/CorsExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Cors/Framework.Cors.csproj
+++ b/src/framework/Framework.Cors/Framework.Cors.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.DBAccess/ContextExtensions.cs
+++ b/src/framework/Framework.DBAccess/ContextExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.DBAccess/EscapeExtensions.cs
+++ b/src/framework/Framework.DBAccess/EscapeExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
+++ b/src/framework/Framework.DBAccess/Framework.DBAccess.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.DateTimeProvider/DependencyInjection/DateTimeProviderExtensions.cs
+++ b/src/framework/Framework.DateTimeProvider/DependencyInjection/DateTimeProviderExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.DateTimeProvider/Framework.DateTimeProvider.csproj
+++ b/src/framework/Framework.DateTimeProvider/Framework.DateTimeProvider.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.DateTimeProvider/IDateTimeProvider.cs
+++ b/src/framework/Framework.DateTimeProvider/IDateTimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.DateTimeProvider/UtcDateTimeProvider.cs
+++ b/src/framework/Framework.DateTimeProvider/UtcDateTimeProvider.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ConfigurationException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ConfigurationException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ConfigurationValidation.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ConfigurationValidation.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ConflictException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ConflictException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ControllerArgumentException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ControllerArgumentException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ErrorResponse.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ErrorResponse.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ForbiddenException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ForbiddenException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/Framework.ErrorHandling.Library.csproj
+++ b/src/framework/Framework.ErrorHandling.Library/Framework.ErrorHandling.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/NotFoundException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/NotFoundException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/ServiceException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/ServiceException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/UnexpectedConditionException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/UnexpectedConditionException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Library/UnsupportedMediaTypeException.cs
+++ b/src/framework/Framework.ErrorHandling.Library/UnsupportedMediaTypeException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Web/Framework.ErrorHandling.Web.csproj
+++ b/src/framework/Framework.ErrorHandling.Web/Framework.ErrorHandling.Web.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
+++ b/src/framework/Framework.ErrorHandling.Web/GeneralHttpErrorHandler.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.IO/AsyncEnumerableStringStream.cs
+++ b/src/framework/Framework.IO/AsyncEnumerableStringStream.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.IO/CancellableStream.cs
+++ b/src/framework/Framework.IO/CancellableStream.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.IO/CsvParser.cs
+++ b/src/framework/Framework.IO/CsvParser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.IO/Framework.IO.csproj
+++ b/src/framework/Framework.IO/Framework.IO.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.IO/UrlHelper.cs
+++ b/src/framework/Framework.IO/UrlHelper.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Logging/Framework.Logging.csproj
+++ b/src/framework/Framework.Logging/Framework.Logging.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Logging/LoggingHandler.cs
+++ b/src/framework/Framework.Logging/LoggingHandler.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Models/Constants.cs
+++ b/src/framework/Framework.Models/Constants.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Models/Framework.Models.csproj
+++ b/src/framework/Framework.Models/Framework.Models.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Models/KeyVaultAuthSettings.cs
+++ b/src/framework/Framework.Models/KeyVaultAuthSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Models/Pagination.cs
+++ b/src/framework/Framework.Models/Pagination.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Models/ValidationExpressions.cs
+++ b/src/framework/Framework.Models/ValidationExpressions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/CustomSeederRunner.cs
+++ b/src/framework/Framework.Seeding/CustomSeederRunner.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/DatabaseInitializer.cs
+++ b/src/framework/Framework.Seeding/DatabaseInitializer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/DbInitializer.cs
+++ b/src/framework/Framework.Seeding/DbInitializer.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/DbSeeder.cs
+++ b/src/framework/Framework.Seeding/DbSeeder.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/DependencyInjection/DatabaseInitializerExtensions.cs
+++ b/src/framework/Framework.Seeding/DependencyInjection/DatabaseInitializerExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/Framework.Seeding.csproj
+++ b/src/framework/Framework.Seeding/Framework.Seeding.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/ICustomSeeder.cs
+++ b/src/framework/Framework.Seeding/ICustomSeeder.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/IDatabaseInitializer.cs
+++ b/src/framework/Framework.Seeding/IDatabaseInitializer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/JsonDateTimeOffsetConverter.cs
+++ b/src/framework/Framework.Seeding/JsonDateTimeOffsetConverter.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Seeding/SeederHelper.cs
+++ b/src/framework/Framework.Seeding/SeederHelper.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Swagger/AddAuthFilter.cs
+++ b/src/framework/Framework.Swagger/AddAuthFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Swagger/BaseStatusCodeFilter.cs
+++ b/src/framework/Framework.Swagger/BaseStatusCodeFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Swagger/Framework.Swagger.csproj
+++ b/src/framework/Framework.Swagger/Framework.Swagger.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Swagger/SwaggerFileOperationFilter.cs
+++ b/src/framework/Framework.Swagger/SwaggerFileOperationFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Swagger/SwaggerGenConfiguration.cs
+++ b/src/framework/Framework.Swagger/SwaggerGenConfiguration.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Token/AuthResponse.cs
+++ b/src/framework/Framework.Token/AuthResponse.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Token/Framework.Token.csproj
+++ b/src/framework/Framework.Token/Framework.Token.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Token/ITokenService.cs
+++ b/src/framework/Framework.Token/ITokenService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Token/TokenService.cs
+++ b/src/framework/Framework.Token/TokenService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Web/ContentTypeMapperExtensions.cs
+++ b/src/framework/Framework.Web/ContentTypeMapperExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Web/Framework.Web.csproj
+++ b/src/framework/Framework.Web/Framework.Web.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/framework/Framework.Web/StartupServiceExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/framework/Framework.Web/StartupServiceWebApplicationExtensions.cs
+++ b/src/framework/Framework.Web/StartupServiceWebApplicationExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Authentication/ClaimRequestPathHandler.cs
+++ b/src/keycloak/Keycloak.Authentication/ClaimRequestPathHandler.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Authentication/ControllerExtensions.cs
+++ b/src/keycloak/Keycloak.Authentication/ControllerExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
+++ b/src/keycloak/Keycloak.Authentication/Keycloak.Authentication.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Authentication/KeycloakClaimsTransformation.cs
+++ b/src/keycloak/Keycloak.Authentication/KeycloakClaimsTransformation.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/FlurlErrorHandler.cs
+++ b/src/keycloak/Keycloak.ErrorHandling/FlurlErrorHandler.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/FlurlUntrustedCertExceptionHandler.cs
+++ b/src/keycloak/Keycloak.ErrorHandling/FlurlUntrustedCertExceptionHandler.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/Keycloak.ErrorHandling.csproj
+++ b/src/keycloak/Keycloak.ErrorHandling/Keycloak.ErrorHandling.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/KeycloakEntityConflictException.cs
+++ b/src/keycloak/Keycloak.ErrorHandling/KeycloakEntityConflictException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/KeycloakEntityNotFoundException.cs
+++ b/src/keycloak/Keycloak.ErrorHandling/KeycloakEntityNotFoundException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.ErrorHandling/KeycloakNoSuccessException.cs
+++ b/src/keycloak/Keycloak.ErrorHandling/KeycloakNoSuccessException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/IKeycloakFactory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Factory/Keycloak.Factory.csproj
+++ b/src/keycloak/Keycloak.Factory/Keycloak.Factory.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
+++ b/src/keycloak/Keycloak.Factory/KeycloakFactory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Factory/KeycloakSettings.cs
+++ b/src/keycloak/Keycloak.Factory/KeycloakSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/keycloak/Keycloak.Library/AttackDetection/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/AttackDetection/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/AuthenticationManagement/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/AuthenticationManagement/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/AuthorizationResource/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/AuthorizationResource/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/AuthorizationScope/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/AuthorizationScope/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientAttributeCertificate/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientAttributeCertificate/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientAuthorization/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientAuthorization/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientInitialAccess/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientInitialAccess/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientRegistrationPolicy/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientRegistrationPolicy/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientRoleMappings/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientRoleMappings/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ClientScopes/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ClientScopes/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Clients/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Clients/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/AccessTokenCategoriesConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/AccessTokenCategoriesConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/AuthorizationPermissionTypeConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/AuthorizationPermissionTypeConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/CategoryConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/CategoryConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/ConfigTypeConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/ConfigTypeConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/DecisionStrategiesConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/DecisionStrategiesConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/GroupNameConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/GroupNameConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/JsonEnumConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/JsonEnumConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/JsonTypeLabelConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/JsonTypeLabelConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/LocaleConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/LocaleConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/NameConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/NameConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/PoliciesConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/PoliciesConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/PolicyDecisionLogicConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/PolicyDecisionLogicConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/PolicyTypeConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/PolicyTypeConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Converters/ProtocolConverter.cs
+++ b/src/keycloak/Keycloak.Library/Common/Converters/ProtocolConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Extensions/DynamicExtensions.cs
+++ b/src/keycloak/Keycloak.Library/Common/Extensions/DynamicExtensions.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/Extensions/FlurlRequestExtensions.cs
+++ b/src/keycloak/Keycloak.Library/Common/Extensions/FlurlRequestExtensions.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Common/ForwardedHttpHeaders.cs
+++ b/src/keycloak/Keycloak.Library/Common/ForwardedHttpHeaders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Components/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Components/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Groups/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Groups/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/IdentityProviders/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/IdentityProviders/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Key/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Key/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Keycloak.Library.csproj
+++ b/src/keycloak/Keycloak.Library/Keycloak.Library.csproj
@@ -2,8 +2,8 @@
 - MIT License
 -
 - Copyright (c) 2019 Luk Vermeulen
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - Permission is hereby granted, free of charge, to any person obtaining a copy
 - of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Keycloak.Net.csproj.DotSettings
+++ b/src/keycloak/Keycloak.Library/Keycloak.Net.csproj.DotSettings
@@ -2,8 +2,8 @@
 - MIT License
 -
 - Copyright (c) 2019 Luk Vermeulen
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - Permission is hereby granted, free of charge, to any person obtaining a copy
 - of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AttackDetection/UserNameStatus.cs
+++ b/src/keycloak/Keycloak.Library/Models/AttackDetection/UserNameStatus.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecution.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecution.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionBase.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionBase.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionById.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionById.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionExport.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionExport.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationExecutionInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationFlow.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationFlow.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationFlowExecution.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticationFlowExecution.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticatorConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticatorConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticatorConfigInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/AuthenticatorConfigInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/RequiredActionProvider.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthenticationManagement/RequiredActionProvider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthorizationPermissions/AuthorizationPermission.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthorizationPermissions/AuthorizationPermission.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthorizationResources/AuthorizationResource.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthorizationResources/AuthorizationResource.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/AuthorizationScopes/AuthorizationScope.cs
+++ b/src/keycloak/Keycloak.Library/Models/AuthorizationScopes/AuthorizationScope.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientAttributeCertificate/Certificate.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientAttributeCertificate/Certificate.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientAttributeCertificate/KeyStoreConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientAttributeCertificate/KeyStoreConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientInitialAccess/ClientInitialAccessCreatePresentation.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientInitialAccess/ClientInitialAccessCreatePresentation.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientInitialAccess/ClientInitialAccessPresentation.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientInitialAccess/ClientInitialAccessPresentation.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientScopes/Attributes.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientScopes/Attributes.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ClientScopes/ClientScope.cs
+++ b/src/keycloak/Keycloak.Library/Models/ClientScopes/ClientScope.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AccessToken.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AccessToken.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenAccess.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenAccess.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenAuthorization.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenAuthorization.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenCategories.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenCategories.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenCertConf.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AccessTokenCertConf.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/AddressClaimSet.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/AddressClaimSet.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/Client.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/Client.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/ClientAccess.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/ClientAccess.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/ClientConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/ClientConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/ClientProtocolMapper.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/ClientProtocolMapper.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/ClientScopeEvaluateResourceProtocolMapperEvaluation.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/ClientScopeEvaluateResourceProtocolMapperEvaluation.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/Permission.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/Permission.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/Resource.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/Resource.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Clients/RolePolicy.cs
+++ b/src/keycloak/Keycloak.Library/Models/Clients/RolePolicy.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Common/ClientRoleMapping.cs
+++ b/src/keycloak/Keycloak.Library/Models/Common/ClientRoleMapping.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Common/ConfigProperty.cs
+++ b/src/keycloak/Keycloak.Library/Models/Common/ConfigProperty.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Common/GlobalRequestResult.cs
+++ b/src/keycloak/Keycloak.Library/Models/Common/GlobalRequestResult.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Common/ManagementPermission.cs
+++ b/src/keycloak/Keycloak.Library/Models/Common/ManagementPermission.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Common/Mapping.cs
+++ b/src/keycloak/Keycloak.Library/Models/Common/Mapping.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Components/Component.cs
+++ b/src/keycloak/Keycloak.Library/Models/Components/Component.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Components/ComponentType.cs
+++ b/src/keycloak/Keycloak.Library/Models/Components/ComponentType.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Components/Config.cs
+++ b/src/keycloak/Keycloak.Library/Models/Components/Config.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Groups/Group.cs
+++ b/src/keycloak/Keycloak.Library/Models/Groups/Group.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/IdentityProviders/Config.cs
+++ b/src/keycloak/Keycloak.Library/Models/IdentityProviders/Config.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProvider.cs
+++ b/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProvider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderMapper.cs
+++ b/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderMapper.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderToken.cs
+++ b/src/keycloak/Keycloak.Library/Models/IdentityProviders/IdentityProviderToken.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Key/Active.cs
+++ b/src/keycloak/Keycloak.Library/Models/Key/Active.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Key/Key.cs
+++ b/src/keycloak/Keycloak.Library/Models/Key/Key.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Key/KeysMetadata.cs
+++ b/src/keycloak/Keycloak.Library/Models/Key/KeysMetadata.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/OpenIDConfiguration/OpenIDConfiguration.cs
+++ b/src/keycloak/Keycloak.Library/Models/OpenIDConfiguration/OpenIDConfiguration.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ProtocolMappers/Config.cs
+++ b/src/keycloak/Keycloak.Library/Models/ProtocolMappers/Config.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/ProtocolMappers/ProtocolMapper.cs
+++ b/src/keycloak/Keycloak.Library/Models/ProtocolMappers/ProtocolMapper.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/AdminEvent.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/AdminEvent.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Attributes.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Attributes.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/AuthDetails.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/AuthDetails.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/BrowserSecurityHeaders.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/BrowserSecurityHeaders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Config.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Config.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Event.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Event.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/IdentityProvider.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/IdentityProvider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/PartialImport.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/PartialImport.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Policies.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Policies.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Realm.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Realm.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/RealmEventsConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/RealmEventsConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Roles.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/Roles.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/RealmsAdmin/SmtpServer.cs
+++ b/src/keycloak/Keycloak.Library/Models/RealmsAdmin/SmtpServer.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Roles/Role.cs
+++ b/src/keycloak/Keycloak.Library/Models/Roles/Role.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Roles/RoleComposite.cs
+++ b/src/keycloak/Keycloak.Library/Models/Roles/RoleComposite.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Account.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Account.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/AccountProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/AccountProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ActionToken.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ActionToken.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ActionTokenHandler.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ActionTokenHandler.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ActionTokenHandlerProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ActionTokenHandlerProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ActionTokenProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ActionTokenProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Authenticator.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Authenticator.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Authorization.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Authorization.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/AuthorizationCache.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/AuthorizationCache.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/AuthorizationPersister.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/AuthorizationPersister.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/AuthorizationPersisterProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/AuthorizationPersisterProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/AuthorizationProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/AuthorizationProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/BruteForceProtector.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/BruteForceProtector.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/BruteForceProtectorProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/BruteForceProtectorProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/BuiltinProtocolMappers.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/BuiltinProtocolMappers.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Category.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Category.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientAuthenticator.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientAuthenticator.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientAuthenticatorProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientAuthenticatorProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientDescriptionConverter.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientDescriptionConverter.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientDescriptionConverterProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientDescriptionConverterProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientInstallation.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientInstallation.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientInstallations.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientInstallations.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientRegistration.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientRegistration.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationPolicy.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationPolicy.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationPolicyProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationPolicyProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientRegistrationProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ClientStorage.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ClientStorage.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Common.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Common.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ComponentTypes.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ComponentTypes.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ConfigType.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ConfigType.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpa.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpa.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaUpdater.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaUpdater.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaUpdaterProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ConnectionsJpaUpdaterProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Credential.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Credential.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/CredentialProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/CredentialProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Default.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Default.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/EmailTemplateClass.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/EmailTemplateClass.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Enums.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Enums.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/EventsListener.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/EventsListener.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/EventsListenerProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/EventsListenerProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ExportProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ExportProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/FormAction.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/FormAction.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/FormActionProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/FormActionProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/FormAuthenticator.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/FormAuthenticator.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/FormAuthenticatorProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/FormAuthenticatorProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/GroupName.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/GroupName.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/HasDefault.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/HasDefault.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/HasOrder.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/HasOrder.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Hash.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Hash.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/HashProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/HashProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Hostname.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Hostname.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/HostnameProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/HostnameProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/IdentityProvider.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/IdentityProvider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/IdentityProviderProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/IdentityProviderProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/JsonTypeLabel.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/JsonTypeLabel.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/JtaLookup.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/JtaLookup.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/JtaLookupProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/JtaLookupProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakAuthenticationAuthenticator.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakAuthenticationAuthenticator.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakAuthenticationFormAction.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakAuthenticationFormAction.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageLdapMappersLdapStorageMapper.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageLdapMappersLdapStorageMapper.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageLdapMappersLdapStorageMapperMetadata.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageLdapMappersLdapStorageMapperMetadata.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageUserStorageProvider.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageUserStorageProvider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageUserStorageProviderMetadata.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeycloakStorageUserStorageProviderMetadata.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Keys.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Keys.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/KeysProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/KeysProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/LdapMapper.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/LdapMapper.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/LdapMapperProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/LdapMapperProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Locale.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Locale.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/LoginProtocol.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/LoginProtocol.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/LoginProtocolProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/LoginProtocolProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/MemoryInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/MemoryInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/MetadataClass.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/MetadataClass.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Name.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Name.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Oauth2TokenIntrospection.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Oauth2TokenIntrospection.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Oauth2TokenIntrospectionProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Oauth2TokenIntrospectionProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/OpenIdConnect.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/OpenIdConnect.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/OpenIdConnectConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/OpenIdConnectConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/OperationalInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/OperationalInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/PasswordPolicy.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/PasswordPolicy.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Policy.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Policy.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/PolicyProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/PolicyProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Port.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Port.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ProfileInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ProfileInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Protocol.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Protocol.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ProtocolMapperType.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ProtocolMapperType.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ProtocolMapperTypes.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ProtocolMapperTypes.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Provider.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Provider.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/RequiredAction.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/RequiredAction.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/RequiredActionProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/RequiredActionProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Saml.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Saml.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/SamlConfig.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/SamlConfig.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Scripting.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Scripting.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ScriptingProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ScriptingProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ServerInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ServerInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ServerInfoProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ServerInfoProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Storage.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Storage.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/StorageProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/StorageProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/SystemInfo.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/SystemInfo.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Theme.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Theme.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/ThemeProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/ThemeProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Themes.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Themes.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Timer.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Timer.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/TimerProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/TimerProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/Truststore.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/Truststore.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/TruststoreProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/TruststoreProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/WellKnown.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/WellKnown.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Root/WellKnownProviders.cs
+++ b/src/keycloak/Keycloak.Library/Models/Root/WellKnownProviders.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/SAMLMetaData/EntityDescriptorType.cs
+++ b/src/keycloak/Keycloak.Library/Models/SAMLMetaData/EntityDescriptorType.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/UserStorageProvider/SynchronizationResult.cs
+++ b/src/keycloak/Keycloak.Library/Models/UserStorageProvider/SynchronizationResult.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/Credentials.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/Credentials.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/FederatedIdentity.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/FederatedIdentity.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/SessionClients.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/SessionClients.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/SetPasswordResponse.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/SetPasswordResponse.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/User.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/User.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/UserAccess.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/UserAccess.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/UserConsent.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/UserConsent.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Models/Users/UserSession.cs
+++ b/src/keycloak/Keycloak.Library/Models/Users/UserSession.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/OpenIDConfiguration/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/OpenIDConfiguration/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ProtocolMappers/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ProtocolMappers/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/RealmsAdmin/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/RealmsAdmin/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/RoleMapper/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/RoleMapper/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Roles/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Roles/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/RolesById/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/RolesById/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Root/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Root/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/SAMLMetaData/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/SAMLMetaData/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/ScopeMappings/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/ScopeMappings/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/UserStorageProvider/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/UserStorageProvider/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/UserStorageProvider/LdapMapperSyncActions.cs
+++ b/src/keycloak/Keycloak.Library/UserStorageProvider/LdapMapperSyncActions.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/UserStorageProvider/UserSyncActions.cs
+++ b/src/keycloak/Keycloak.Library/UserStorageProvider/UserSyncActions.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/keycloak/Keycloak.Library/Users/KeycloakClient.cs
+++ b/src/keycloak/Keycloak.Library/Users/KeycloakClient.cs
@@ -2,8 +2,8 @@
  * MIT License
  *
  * Copyright (c) 2019 Luk Vermeulen
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/mailing/Mailing.SendMail/IMailingService.cs
+++ b/src/mailing/Mailing.SendMail/IMailingService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/ISendMail.cs
+++ b/src/mailing/Mailing.SendMail/ISendMail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/MailSettings.cs
+++ b/src/mailing/Mailing.SendMail/MailSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/Mailing.SendMail.csproj
+++ b/src/mailing/Mailing.SendMail/Mailing.SendMail.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/MailingService.cs
+++ b/src/mailing/Mailing.SendMail/MailingService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/MailingStartupServiceExtensions.cs
+++ b/src/mailing/Mailing.SendMail/MailingStartupServiceExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.SendMail/SendMail.cs
+++ b/src/mailing/Mailing.SendMail/SendMail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/Attributes/PathAttribute.cs
+++ b/src/mailing/Mailing.Template/Attributes/PathAttribute.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/Enums/EmailTemplateType.cs
+++ b/src/mailing/Mailing.Template/Enums/EmailTemplateType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/ITemplateManager.cs
+++ b/src/mailing/Mailing.Template/ITemplateManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/Mailing.Template.csproj
+++ b/src/mailing/Mailing.Template/Mailing.Template.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/Model/Mail.cs
+++ b/src/mailing/Mailing.Template/Model/Mail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/Model/MailTemplate.cs
+++ b/src/mailing/Mailing.Template/Model/MailTemplate.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/NoSuchTemplateException.cs
+++ b/src/mailing/Mailing.Template/NoSuchTemplateException.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/TemplateManager.cs
+++ b/src/mailing/Mailing.Template/TemplateManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/mailing/Mailing.Template/TemplateSettings.cs
+++ b/src/mailing/Mailing.Template/TemplateSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/maintenance/Maintenance.App/BatchDeleteService.cs
+++ b/src/maintenance/Maintenance.App/BatchDeleteService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/maintenance/Maintenance.App/Maintenance.App.csproj
+++ b/src/maintenance/Maintenance.App/Maintenance.App.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/maintenance/Maintenance.App/Program.cs
+++ b/src/maintenance/Maintenance.App/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/Apps.Service.csproj
+++ b/src/marketplace/Apps.Service/Apps.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppReleaseBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppReleaseBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppReleaseProcessController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/Program.cs
+++ b/src/marketplace/Apps.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppData.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppDetailResponse.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppDetailResponse.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppEditableDetail.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppEditableDetail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppInputModel.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppInputModel.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppRequestModel.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppRequestModel.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Apps.Service/ViewModels/AppUserRole.cs
+++ b/src/marketplace/Apps.Service/ViewModels/AppUserRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/DependencyInjection/OfferSetupServiceExtensions.cs
+++ b/src/marketplace/Offers.Library/DependencyInjection/OfferSetupServiceExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Models/BusinessAppData.cs
+++ b/src/marketplace/Offers.Library/Models/BusinessAppData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Models/LocalizedDescription.cs
+++ b/src/marketplace/Offers.Library/Models/LocalizedDescription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Models/OfferProviderResponse.cs
+++ b/src/marketplace/Offers.Library/Models/OfferProviderResponse.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Models/OfferServiceAutoSetupData.cs
+++ b/src/marketplace/Offers.Library/Models/OfferServiceAutoSetupData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Models/OfferingData.cs
+++ b/src/marketplace/Offers.Library/Models/OfferingData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Offers.Library.csproj
+++ b/src/marketplace/Offers.Library/Offers.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferSetupService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/IOfferSubscriptionService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferSubscriptionService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/OfferSetupService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSetupService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferSubscriptionService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/Program.cs
+++ b/src/marketplace/Services.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/ServiceSettings.cs
+++ b/src/marketplace/Services.Service/ServiceSettings.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/Services.Service.csproj
+++ b/src/marketplace/Services.Service/Services.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceDetailResponse.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/marketplace/Services.Service/ViewModels/ServiceUpdateData.cs
+++ b/src/marketplace/Services.Service/ViewModels/ServiceUpdateData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Library/INotificationService.cs
+++ b/src/notifications/Notifications.Library/INotificationService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Library/NotificationService.cs
+++ b/src/notifications/Notifications.Library/NotificationService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Library/Notifications.Library.csproj
+++ b/src/notifications/Notifications.Library/Notifications.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/BusinessLogic/INotificationBusinessLogic.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/INotificationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/NotificationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/BusinessLogic/NotificationSettings.cs
+++ b/src/notifications/Notifications.Service/BusinessLogic/NotificationSettings.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/Controllers/NotificationController.cs
+++ b/src/notifications/Notifications.Service/Controllers/NotificationController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/Notifications.Service.csproj
+++ b/src/notifications/Notifications.Service/Notifications.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/notifications/Notifications.Service/Program.cs
+++ b/src/notifications/Notifications.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/IPortalRepositories.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/IPortalRepositories.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/AgreementData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/AgreementData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/AllOfferData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/AllOfferData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/AppUpdateData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/AppUpdateData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/AppWithSubscriptionStatus.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/AppWithSubscriptionStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/BpdmData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/BpdmData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ClearinghouseData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ClearinghouseData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ClientRoles.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ClientRoles.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyAddressDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyAddressDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyAppUserDetails.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyAppUserDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationStatusUserData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationStatusUserData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationUserData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationUserData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationUserEmailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationUserEmailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithCompanyUserDetails.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithCompanyUserDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyApplicationWithStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyIamUser.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyIamUser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyInformationData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyInformationData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyInvitedUserData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyInvitedUserData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyNameIdBpnIdpAlias.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyNameIdBpnIdpAlias.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleAgreementConsentData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleAgreementConsentData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleAgreementConsents.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleAgreementConsents.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyRoleData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountDetailedData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountWithRoleDataClientId.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyServiceAccountWithRoleDataClientId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanySubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanySubscriptionStatusData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserAccountData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserAccountData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserBusinessPartners.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserBusinessPartners.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserDetails.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserFilter.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserNameData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserNameData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserRoleWithAddress.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserRoleWithAddress.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserRoleWithId.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserRoleWithId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserWithIdpBusinessPartnerData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/CompanyUserWithIdpBusinessPartnerData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConnectorData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ConsentDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ConsentDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/DocumentSeedData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/DocumentSeedData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/IdpUser.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/IdpUser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/InReviewAppData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/InReviewAppData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/InvitedUserDetail.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/InvitedUserDetail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/LanguageData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/LanguageData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/NotificationCountDetails.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/NotificationCountDetails.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/NotificationCreationData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/NotificationCreationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/NotificationDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/NotificationDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/NotificationSorting.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/NotificationSorting.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferAgreementConsent.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferAgreementConsent.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferCompanySubscriptionStatusData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailsData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferDetailsData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferIamUserData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferIamUserData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderDetailsData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferProviderDetailsData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferReleaseData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferReleaseData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferRoleInfos.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferRoleInfos.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSorting.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSorting.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferThirdPartyAutoSetupData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferThirdPartyAutoSetupData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/RegistrationData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/RegistrationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/RequesterData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/RequesterData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ServiceOverviewData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ServiceOverviewData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ServiceOverviewSorting.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ServiceOverviewSorting.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ServiceProviderDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ServiceProviderDetailData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/ServiceUpdateData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/ServiceUpdateData.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/SubscriptionDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/SubscriptionDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/SubscriptionStatusSorting.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/SubscriptionStatusSorting.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UniqueIdentifierData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UniqueIdentifierData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UploadDocuments.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UploadDocuments.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UseCaseData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UseCaseData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserBpn.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserBpn.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/UserRoleData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Models/WelcomeEmailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/WelcomeEmailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/PortalBackend.DBAccess.csproj
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalBackend.DBAccess.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/PortalRepositories.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalRepositories.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/PortalRepositoriesStartupServiceExtensions.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/PortalRepositoriesStartupServiceExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/AgreementRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/AgreementRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/AppInstanceRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/AppInstanceRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/AppSubscriptionDetailRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/AppSubscriptionDetailRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationChecklistRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationChecklistRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ClientRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ClientRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CompanyRolesRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentAssignedOfferSubscriptionRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentAssignedOfferSubscriptionRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConsentRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/CountryRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/CountryRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/DocumentRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IAgreementRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IAgreementRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IAppInstanceRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IAppInstanceRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IAppSubscriptionDetailRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IAppSubscriptionDetailRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationChecklistRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IClientRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IClientRepository.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICompanyRolesRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConnectorsRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConsentAssignedOfferSubscriptionRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConsentAssignedOfferSubscriptionRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IConsentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IConsentRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ICountryRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ICountryRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IDocumentRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IDocumentRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IInvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IInvitationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ILanguageRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ILanguageRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/INotificationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IServiceAccountRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IStaticDataRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IStaticDataRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserBusinessPartnerRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserBusinessPartnerRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/InvitationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/InvitationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/LanguageRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/LanguageRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/NotificationRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ServiceAccountRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/StaticDataRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/StaticDataRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserBusinessPartnerRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserBusinessPartnerRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230110122501_1.0.0-RC1.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230110122501_1.0.0-RC1.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230110122501_1.0.0-RC1.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230110122501_1.0.0-RC1.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230113092045_CPLP-1900-CompanyIdentifiersRename.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230113092045_CPLP-1900-CompanyIdentifiersRename.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230113092045_CPLP-1900-CompanyIdentifiersRename.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230113092045_CPLP-1900-CompanyIdentifiersRename.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230118083612_CPLP-1963-AddChecklist.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230118083612_CPLP-1963-AddChecklist.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230118083612_CPLP-1963-AddChecklist.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230118083612_CPLP-1963-AddChecklist.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230120085449_CPLP-1975-RemoveOfferThumbnailUrl.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230120085449_CPLP-1975-RemoveOfferThumbnailUrl.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230120085449_CPLP-1975-RemoveOfferThumbnailUrl.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230120085449_CPLP-1975-RemoveOfferThumbnailUrl.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230120091306_CPLP-1903-BpdmIdentifier.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230120091306_CPLP-1903-BpdmIdentifier.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230120091306_CPLP-1903-BpdmIdentifier.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230120091306_CPLP-1903-BpdmIdentifier.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230123044031_CPLP-1976-RemoveAppDetailImages.Designer.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230123044031_CPLP-1976-RemoveAppDetailImages.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/20230123044031_CPLP-1976-RemoveAppDetailImages.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/20230123044031_CPLP-1976-RemoveAppDetailImages.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Migrations/PortalDbContextModelSnapshot.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Migrations/PortalDbContextModelSnapshot.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
+++ b/src/portalbackend/PortalBackend.Migrations/PortalBackend.Migrations.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Program.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.Migrations/Seeder/BatchSeeder.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Seeder/BatchSeeder.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditAppSubscriptionDetail20221118.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditAppSubscriptionDetail20221118.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyApplication20221005.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyApplication20221005.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyUser20221005.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyUser20221005.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyUserAssignedRole20221018.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditCompanyUserAssignedRole20221018.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditOffer20230119.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditOffer20230119.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditOfferSubscription20221005.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditOfferSubscription20221005.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditUserRole20221017.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/AuditEntities/AuditUserRole20221017.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditEntityV1Attribute.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditEntityV1Attribute.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditInsertEditorV1Attribute.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditInsertEditorV1Attribute.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditLastEditorV1Attribute.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditLastEditorV1Attribute.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditPropertyV1Names.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/AuditPropertyV1Names.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/EntityTypeBuilderV1Extension.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/EntityTypeBuilderV1Extension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/IAuditEntityV1.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/IAuditEntityV1.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Auditing/IAuditableV1.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Auditing/IAuditableV1.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Address.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Address.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Agreement.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Agreement.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedCompanyRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedCompanyRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedDocument.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedDocument.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedOffer.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedOffer.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedOfferType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementAssignedOfferType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementCategory.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AgreementCategory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AppAssignedUseCase.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AppAssignedUseCase.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AppInstance.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AppInstance.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AppLanguage.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AppLanguage.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AppSubscriptionDetail.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AppSubscriptionDetail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntry.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntry.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntryStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntryStatus.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntryType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ApplicationChecklistEntryType.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/AuditOperation.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/AuditOperation.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/BpdmIdentifier.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/BpdmIdentifier.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Company.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Company.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplication.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplicationStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyApplicationStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyAssignedRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyAssignedRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyAssignedUseCase.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyAssignedUseCase.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyIdentifier.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyIdentifier.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyIdentityProvider.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyIdentityProvider.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleAssignedRoleCollection.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleAssignedRoleCollection.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleDescription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleDescription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleRegistrationData.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyRoleRegistrationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccount.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccount.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountAssignedRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountAssignedRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyServiceAccountType.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUser.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedAppFavourite.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedAppFavourite.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedBusinessPartner.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedBusinessPartner.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserAssignedRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CompanyUserStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Connector.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Connector.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConnectorType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Consent.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Consent.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentAssignedOffer.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentAssignedOffer.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentAssignedOfferSubscription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentAssignedOfferSubscription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ConsentStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Country.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Country.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/CountryAssignedIdentifier.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/CountryAssignedIdentifier.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Document.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Document.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/DocumentStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/DocumentStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/DocumentType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/DocumentType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IamClient.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IamClient.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IamIdentityProvider.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IamIdentityProvider.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IamServiceAccount.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IamServiceAccount.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IamUser.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IamUser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IdentityProvider.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IdentityProvider.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/IdentityProviderCategory.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/IdentityProviderCategory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Invitation.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Invitation.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/InvitationStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/InvitationStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Language.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Language.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Notification.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Notification.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationTopic.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationTopic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationTypeAssignedTopic.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/NotificationTypeAssignedTopic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/Offer.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/Offer.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferAssignedDocument.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferAssignedDocument.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferAssignedLicense.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferAssignedLicense.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferDescription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferDescription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferLicense.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferLicense.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscriptionStatus.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferSubscriptionStatus.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferTag.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferTag.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/OfferType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ProviderCompanyDetail.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ProviderCompanyDetail.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ServiceAssignedServiceType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ServiceAssignedServiceType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/ServiceType.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/ServiceType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UniqueIdentifier.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UniqueIdentifier.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UseCase.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UseCase.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRole.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRole.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleAssignedCollection.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleAssignedCollection.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleCollection.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleCollection.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleCollectionDescription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleCollectionDescription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleDescription.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Entities/UserRoleDescription.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/AgreementCategoryId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/AgreementCategoryId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ApplicationChecklistEntryStateId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ApplicationChecklistEntryStateId.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ApplicationChecklistEntryTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ApplicationChecklistEntryTypeId.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/AuditOperationId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/AuditOperationId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/BpdmIdentifierId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/BpdmIdentifierId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusFilter.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyApplicationStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyRoleId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyRoleId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyServiceAccountStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyServiceAccountStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyServiceAccountTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyServiceAccountTypeId.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyUserStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/CompanyUserStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ConnectorStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ConnectorStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ConnectorTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ConnectorTypeId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ConsentStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ConsentStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/DocumentStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/DocumentStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/DocumentTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/DocumentTypeId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/IdentityProviderCategoryId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/IdentityProviderCategoryId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/InvitationStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/InvitationStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/NotificationTopicId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/NotificationTopicId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/NotificationTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/NotificationTypeId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferStatusIdFilter.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferStatusIdFilter.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferSubscriptionStatusId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferSubscriptionStatusId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/OfferTypeId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/ServiceTypeId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/ServiceTypeId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/Enums/UniqueIdentifierId.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/Enums/UniqueIdentifierId.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/PortalBackend.PortalEntities.csproj
+++ b/src/portalbackend/PortalBackend.PortalEntities/PortalBackend.PortalEntities.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/portalbackend/PortalBackend.PortalEntities/PortalDbContext.cs
+++ b/src/portalbackend/PortalBackend.PortalEntities/PortalDbContext.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.DBAccess/IProvisioningDBAccess.cs
+++ b/src/provisioning/Provisioning.DBAccess/IProvisioningDBAccess.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.DBAccess/Provisioning.DBAccess.csproj
+++ b/src/provisioning/Provisioning.DBAccess/Provisioning.DBAccess.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/provisioning/Provisioning.DBAccess/ProvisioningDBAccess.cs
+++ b/src/provisioning/Provisioning.DBAccess/ProvisioningDBAccess.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Enums/IamClientAuthMethod.cs
+++ b/src/provisioning/Provisioning.Library/Enums/IamClientAuthMethod.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderClientAuthMethod.cs
+++ b/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderClientAuthMethod.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderProtocol.cs
+++ b/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderProtocol.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderSignatureAlgorithm.cs
+++ b/src/provisioning/Provisioning.Library/Enums/IamIdentityProviderSignatureAlgorithm.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Enums/IdentityProviderMapperType.cs
+++ b/src/provisioning/Provisioning.Library/Enums/IdentityProviderMapperType.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/ClientManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/ClientManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/ClientSettings.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/ClientSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/IdentityProviderSettings.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/IdentityProviderSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/OpenIDConfigurationManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/OpenIDConfigurationManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/RealmManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/RealmManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/RealmSettings.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/RealmSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/RoleManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/RoleManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/ServiceAccountManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/ServiceAccountManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/ServiceAccountSettings.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/ServiceAccountSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/UserManager.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/UserManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Extensions/UserSettings.cs
+++ b/src/provisioning/Provisioning.Library/Extensions/UserSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/IProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/IProvisioningManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/ClientAuthData.cs
+++ b/src/provisioning/Provisioning.Library/Models/ClientAuthData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/ClientConfigData.cs
+++ b/src/provisioning/Provisioning.Library/Models/ClientConfigData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/ClientConfigRolesData.cs
+++ b/src/provisioning/Provisioning.Library/Models/ClientConfigRolesData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderClientConfig.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderClientConfig.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigOidc.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigOidc.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigSaml.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderConfigSaml.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderLink.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderLink.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/IdentityProviderMapper.cs
+++ b/src/provisioning/Provisioning.Library/Models/IdentityProviderMapper.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/ServiceAccountCreationInfo.cs
+++ b/src/provisioning/Provisioning.Library/Models/ServiceAccountCreationInfo.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/ServiceAccountData.cs
+++ b/src/provisioning/Provisioning.Library/Models/ServiceAccountData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/UserCreationInfo.cs
+++ b/src/provisioning/Provisioning.Library/Models/UserCreationInfo.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/UserCreationRoleDataIdpInfo.cs
+++ b/src/provisioning/Provisioning.Library/Models/UserCreationRoleDataIdpInfo.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Models/UserProfile.cs
+++ b/src/provisioning/Provisioning.Library/Models/UserProfile.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Provisioning.Library.csproj
+++ b/src/provisioning/Provisioning.Library/Provisioning.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/ProvisioningManager.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManager.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/ProvisioningManagerStartupServiceExtensions.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningManagerStartupServiceExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
+++ b/src/provisioning/Provisioning.Library/ProvisioningSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Service/IServiceAccountCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/IServiceAccountCreation.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Service/IUserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/IUserProvisioningService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Service/ServiceAccountCreation.cs
+++ b/src/provisioning/Provisioning.Library/Service/ServiceAccountCreation.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
+++ b/src/provisioning/Provisioning.Library/Service/UserProvisioningService.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Mail/IUserEmail.cs
+++ b/src/provisioning/Provisioning.Mail/IUserEmail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Mail/Provisioning.Mail.csproj
+++ b/src/provisioning/Provisioning.Mail/Provisioning.Mail.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Mail/UserEmail.cs
+++ b/src/provisioning/Provisioning.Mail/UserEmail.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Mail/UserEmailSettings.cs
+++ b/src/provisioning/Provisioning.Mail/UserEmailSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/Migrations/20230105115124_1.0.0-RC1.Designer.cs
+++ b/src/provisioning/Provisioning.Migrations/Migrations/20230105115124_1.0.0-RC1.Designer.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/Migrations/20230105115124_1.0.0-RC1.cs
+++ b/src/provisioning/Provisioning.Migrations/Migrations/20230105115124_1.0.0-RC1.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/Migrations/ProvisioningDbContextModelSnapshot.cs
+++ b/src/provisioning/Provisioning.Migrations/Migrations/ProvisioningDbContextModelSnapshot.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/Program.cs
+++ b/src/provisioning/Provisioning.Migrations/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
+++ b/src/provisioning/Provisioning.Migrations/Provisioning.Migrations.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Migrations/ProvisioningDbContextFactory.cs
+++ b/src/provisioning/Provisioning.Migrations/ProvisioningDbContextFactory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.ProvisioningEntities/Entities/ClientSequence.cs
+++ b/src/provisioning/Provisioning.ProvisioningEntities/Entities/ClientSequence.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.ProvisioningEntities/Entities/IdentityProviderSequence.cs
+++ b/src/provisioning/Provisioning.ProvisioningEntities/Entities/IdentityProviderSequence.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.ProvisioningEntities/Entities/UserPasswordReset.cs
+++ b/src/provisioning/Provisioning.ProvisioningEntities/Entities/UserPasswordReset.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.ProvisioningEntities/Provisioning.ProvisioningEntities.csproj
+++ b/src/provisioning/Provisioning.ProvisioningEntities/Provisioning.ProvisioningEntities.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/provisioning/Provisioning.ProvisioningEntities/ProvisioningDbContext.cs
+++ b/src/provisioning/Provisioning.ProvisioningEntities/ProvisioningDbContext.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/BusinessLogic/ClientBusinessLogic.cs
+++ b/src/provisioning/Provisioning.Service/BusinessLogic/ClientBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/BusinessLogic/IClientBusinessLogic.cs
+++ b/src/provisioning/Provisioning.Service/BusinessLogic/IClientBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/Controllers/ClientController.cs
+++ b/src/provisioning/Provisioning.Service/Controllers/ClientController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/Models/ClientSetupData.cs
+++ b/src/provisioning/Provisioning.Service/Models/ClientSetupData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/Models/IdentityProviderSetupData.cs
+++ b/src/provisioning/Provisioning.Service/Models/IdentityProviderSetupData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/Program.cs
+++ b/src/provisioning/Provisioning.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/provisioning/Provisioning.Service/Provisioning.Service.csproj
+++ b/src/provisioning/Provisioning.Service/Provisioning.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/registration/ApplicationActivation.Library/ApplicationActivation.Library.csproj
+++ b/src/registration/ApplicationActivation.Library/ApplicationActivation.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
+++ b/src/registration/ApplicationActivation.Library/ApplicationActivationService.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationExtensions.cs
+++ b/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationSettings.cs
+++ b/src/registration/ApplicationActivation.Library/DependencyInjection/ApplicationActivationSettings.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/ApplicationActivation.Library/IApplicationActivationService.cs
+++ b/src/registration/ApplicationActivation.Library/IApplicationActivationService.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/BpnAccess.cs
+++ b/src/registration/Registration.Service/Bpn/BpnAccess.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/BpnAccessCollectionExtension.cs
+++ b/src/registration/Registration.Service/Bpn/BpnAccessCollectionExtension.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/IBpnAccess.cs
+++ b/src/registration/Registration.Service/Bpn/IBpnAccess.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/Model/BpdmAddressDto.cs
+++ b/src/registration/Registration.Service/Bpn/Model/BpdmAddressDto.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/Model/BpdmLegalEntityDto.cs
+++ b/src/registration/Registration.Service/Bpn/Model/BpdmLegalEntityDto.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Bpn/Model/FetchBusinessPartnerDto.cs
+++ b/src/registration/Registration.Service/Bpn/Model/FetchBusinessPartnerDto.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/IRegistrationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
+++ b/src/registration/Registration.Service/BusinessLogic/RegistrationSettings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/BusinessLogic/UpdateApplicationSteps.cs
+++ b/src/registration/Registration.Service/BusinessLogic/UpdateApplicationSteps.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Controllers/RegistrationController.cs
+++ b/src/registration/Registration.Service/Controllers/RegistrationController.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/CompanyApplicationData.cs
+++ b/src/registration/Registration.Service/Model/CompanyApplicationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/CompanyBpdmDetailData.cs
+++ b/src/registration/Registration.Service/Model/CompanyBpdmDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/CompanyDetailData.cs
+++ b/src/registration/Registration.Service/Model/CompanyDetailData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/CompanyRegistrationData.cs
+++ b/src/registration/Registration.Service/Model/CompanyRegistrationData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/CompanyRoleAgreementData.cs
+++ b/src/registration/Registration.Service/Model/CompanyRoleAgreementData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Model/InvitedUser.cs
+++ b/src/registration/Registration.Service/Model/InvitedUser.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Program.cs
+++ b/src/registration/Registration.Service/Program.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/registration/Registration.Service/Registration.Service.csproj
+++ b/src/registration/Registration.Service/Registration.Service.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Administration.Service.Tests.csproj
+++ b/tests/administration/Administration.Service.Tests/Administration.Service.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ConnectorsBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/DapsServiceTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/DapsServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/DocumentsBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/DocumentsBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/IdentityProviderBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/InvitationBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceAccountBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceProviderBusinessLogicTest.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/ServiceProviderBusinessLogicTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/UserBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/BusinessLogic/UserUploadBusinessLogicTests.cs
+++ b/tests/administration/Administration.Service.Tests/BusinessLogic/UserUploadBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ConnectorsControllerTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Controllers/PartnerNetworkControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/PartnerNetworkControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/RegistrationControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Controllers/ServiceProviderControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/ServiceProviderControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/Controllers/UserControllerTest.cs
+++ b/tests/administration/Administration.Service.Tests/Controllers/UserControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/EndpointSetup/ConnectorsEndpoints.cs
+++ b/tests/administration/Administration.Service.Tests/EndpointSetup/ConnectorsEndpoints.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
+++ b/tests/administration/Administration.Service.Tests/IntegrationTests/ConnectorsControllerIntegrationTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/checklist/Checklist.Library.Tests/Checklist.Library.Tests.csproj
+++ b/tests/checklist/Checklist.Library.Tests/Checklist.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/checklist/Checklist.Library.Tests/ChecklistCreationServiceTests.cs
+++ b/tests/checklist/Checklist.Library.Tests/ChecklistCreationServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/checklist/Checklist.Library.Tests/ChecklistServiceTests.cs
+++ b/tests/checklist/Checklist.Library.Tests/ChecklistServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/checklist/Checklist.Library.Tests/Usings.cs
+++ b/tests/checklist/Checklist.Library.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/checklist/Checklist.Worker.Tests/Checklist.Worker.Tests.csproj
+++ b/tests/checklist/Checklist.Worker.Tests/Checklist.Worker.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/checklist/Checklist.Worker.Tests/ChecklistExecutionServiceTests.cs
+++ b/tests/checklist/Checklist.Worker.Tests/ChecklistExecutionServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/checklist/Checklist.Worker.Tests/Usings.cs
+++ b/tests/checklist/Checklist.Worker.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Bpdm.Library/Bpdm.Library.csproj
+++ b/tests/externalsystems/Bpdm.Library/Bpdm.Library.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
+++ b/tests/externalsystems/Bpdm.Library/BpdmServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Bpdm.Library/Usings.cs
+++ b/tests/externalsystems/Bpdm.Library/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Clearinghouse.Library.Tests/Clearinghouse.Library.Tests.csproj
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/Clearinghouse.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseServiceTests.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/ClearinghouseServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Clearinghouse.Library.Tests/Usings.cs
+++ b/tests/externalsystems/Clearinghouse.Library.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Custodian.Library.Tests/Custodian.Library.Tests.csproj
+++ b/tests/externalsystems/Custodian.Library.Tests/Custodian.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/externalsystems/Custodian.Library.Tests/CustodianBusinessLogicTests.cs
+++ b/tests/externalsystems/Custodian.Library.Tests/CustodianBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
+++ b/tests/externalsystems/Custodian.Library.Tests/CustodianServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/Custodian.Library.Tests/Usings.cs
+++ b/tests/externalsystems/Custodian.Library.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactory.Library.Tests.csproj
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactory.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/SdFactoryServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/externalsystems/SdFactory.Library.Tests/Usings.cs
+++ b/tests/externalsystems/SdFactory.Library.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.DBAccess.Tests/ContextExtensionsTests.cs
+++ b/tests/framework/Framework.DBAccess.Tests/ContextExtensionsTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.DBAccess.Tests/Framework.DBAccess.Tests.csproj
+++ b/tests/framework/Framework.DBAccess.Tests/Framework.DBAccess.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/framework/Framework.ErrorHandling.Web.Tests/Framework.ErrorHandling.Web.Tests.csproj
+++ b/tests/framework/Framework.ErrorHandling.Web.Tests/Framework.ErrorHandling.Web.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/framework/Framework.ErrorHandling.Web.Tests/GeneralHttpErrorHandlerTests.cs
+++ b/tests/framework/Framework.ErrorHandling.Web.Tests/GeneralHttpErrorHandlerTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.IO.Tests/AsyncEnumerableStringStreamTest.cs
+++ b/tests/framework/Framework.IO.Tests/AsyncEnumerableStringStreamTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.IO.Tests/CancelableStreamTest.cs
+++ b/tests/framework/Framework.IO.Tests/CancelableStreamTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.IO.Tests/CsvParserTest.cs
+++ b/tests/framework/Framework.IO.Tests/CsvParserTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.IO.Tests/Framework.IO.Tests.csproj
+++ b/tests/framework/Framework.IO.Tests/Framework.IO.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/framework/Framework.Token.Tests/Framework.Token.Tests.csproj
+++ b/tests/framework/Framework.Token.Tests/Framework.Token.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/framework/Framework.Token.Tests/TokenServiceTests.cs
+++ b/tests/framework/Framework.Token.Tests/TokenServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.Token.Tests/Usings.cs
+++ b/tests/framework/Framework.Token.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.Web.Tests/ContentTypeMapperExtensionsTests.cs
+++ b/tests/framework/Framework.Web.Tests/ContentTypeMapperExtensionsTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/framework/Framework.Web.Tests/Framework.Web.Tests.csproj
+++ b/tests/framework/Framework.Web.Tests/Framework.Web.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/maintenance/Maintenance.App.Tests/BatchDeleteServiceTests.cs
+++ b/tests/maintenance/Maintenance.App.Tests/BatchDeleteServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/maintenance/Maintenance.App.Tests/Maintenance.App.Tests.csproj
+++ b/tests/maintenance/Maintenance.App.Tests/Maintenance.App.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/maintenance/Maintenance.App.Tests/Setup/TestDbFixture.cs
+++ b/tests/maintenance/Maintenance.App.Tests/Setup/TestDbFixture.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/maintenance/Maintenance.App.Tests/Usings.cs
+++ b/tests/maintenance/Maintenance.App.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Apps.Service.Tests/Apps.Service.Tests.csproj
+++ b/tests/marketplace/Apps.Service.Tests/Apps.Service.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppReleaseBusinessLogicTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppReleaseProcessControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Offers.Library.Tests/Offers.Library.Tests.csproj
+++ b/tests/marketplace/Offers.Library.Tests/Offers.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSetupServiceTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferSubscriptionServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferSubscriptionServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/marketplace/Services.Service.Tests/Services.Service.Tests.csproj
+++ b/tests/marketplace/Services.Service.Tests/Services.Service.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/notifications/Notifications.Library.Tests/NotificationServiceTests.cs
+++ b/tests/notifications/Notifications.Library.Tests/NotificationServiceTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/notifications/Notifications.Library.Tests/Notifications.Library.Tests.csproj
+++ b/tests/notifications/Notifications.Library.Tests/Notifications.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/BusinessLogic/NotificationBusinessLogicTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
+++ b/tests/notifications/Notifications.Service.Tests/Controllers/NotificationControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/notifications/Notifications.Service.Tests/EnpointSetup/NotificationEndpoints.cs
+++ b/tests/notifications/Notifications.Service.Tests/EnpointSetup/NotificationEndpoints.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/notifications/Notifications.Service.Tests/IntegrationTests/NotificationControllerIntegrationTests.cs
+++ b/tests/notifications/Notifications.Service.Tests/IntegrationTests/NotificationControllerIntegrationTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/notifications/Notifications.Service.Tests/Notifications.Service.Tests.csproj
+++ b/tests/notifications/Notifications.Service.Tests/Notifications.Service.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/AgreementRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationChecklistRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationChecklistRepositoryTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ApplicationRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryFakeDbTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryFakeDbTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/CompanyRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConsentRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConsentRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/DocumentRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/DocumentRepositoryTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/InMemoryDbContextFactory.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/InMemoryDbContextFactory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/LanguageRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/LanguageRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/NotificationRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackend.DBAccess.Tests.csproj
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackend.DBAccess.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackendDBAccessTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/PortalBackendDBAccessTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceAccountRespotitoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ServiceRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Setup/TestDbFixture.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/StaticDataRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/StaticDataRepositoryTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryFakeDbTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryFakeDbTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/UserRepositoryTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.DBAccess.Tests/Provisioning.DBAccess.Tests.csproj
+++ b/tests/provisioning/Provisioning.DBAccess.Tests/Provisioning.DBAccess.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.DBAccess.Tests/ProvisioningDBAccessTests.cs
+++ b/tests/provisioning/Provisioning.DBAccess.Tests/ProvisioningDBAccessTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.DBAccess.Tests/Setup/TestDbFixture.cs
+++ b/tests/provisioning/Provisioning.DBAccess.Tests/Setup/TestDbFixture.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.DBAccess.Tests/TestSeeds/BaseSeed.cs
+++ b/tests/provisioning/Provisioning.DBAccess.Tests/TestSeeds/BaseSeed.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.Library.Tests/Provisioning.Library.Tests.csproj
+++ b/tests/provisioning/Provisioning.Library.Tests/Provisioning.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceAuxiliaryMethodsTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceAuxiliaryMethodsTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceCreateUsersTests.cs
+++ b/tests/provisioning/Provisioning.Library.Tests/UserProvisioningServiceCreateUsersTests.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/ApplicationActivation.Library.Tests/ApplicationActivation.Library.Tests.csproj
+++ b/tests/registration/ApplicationActivation.Library.Tests/ApplicationActivation.Library.Tests.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/registration/ApplicationActivation.Library.Tests/ApplicationActivationTests.cs
+++ b/tests/registration/ApplicationActivation.Library.Tests/ApplicationActivationTests.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/ApplicationActivation.Library.Tests/Usings.cs
+++ b/tests/registration/ApplicationActivation.Library.Tests/Usings.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/Registration.Service.Tests/BPNAccessTest.cs
+++ b/tests/registration/Registration.Service.Tests/BPNAccessTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
+++ b/tests/registration/Registration.Service.Tests/BusinessLogic/RegistrationBusinessLogicTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
+++ b/tests/registration/Registration.Service.Tests/Controller/RegistrationControllerTest.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 Microsoft and BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/registration/Registration.Service.Tests/Registration.Service.Tests.csproj
+++ b/tests/registration/Registration.Service.Tests/Registration.Service.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<!--
-- Copyright (c) 2021,2022 Microsoft and BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 Microsoft and BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/AsyncEnumerableStub.cs
+++ b/tests/shared/Tests.Shared/AsyncEnumerableStub.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/AsyncEnumeratorStub.cs
+++ b/tests/shared/Tests.Shared/AsyncEnumeratorStub.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/AsyncQueryProviderStub.cs
+++ b/tests/shared/Tests.Shared/AsyncQueryProviderStub.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/Extensions/ControllerExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/ControllerExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/Extensions/FakeDbSetExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/FakeDbSetExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/Extensions/HttpExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/HttpExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/Extensions/IFixtureExtensions.cs
+++ b/tests/shared/Tests.Shared/Extensions/IFixtureExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/FormFileHelper.cs
+++ b/tests/shared/Tests.Shared/FormFileHelper.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/HttpMessageHandlerMock.cs
+++ b/tests/shared/Tests.Shared/HttpMessageHandlerMock.cs
@@ -1,6 +1,6 @@
 ﻿/********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/IntegrationTests/EndpointSetup/Paths.cs
+++ b/tests/shared/Tests.Shared/IntegrationTests/EndpointSetup/Paths.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/IntegrationTests/FakePolicyEvaluator.cs
+++ b/tests/shared/Tests.Shared/IntegrationTests/FakePolicyEvaluator.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/IntegrationTests/IntegrationTestFactory.cs
+++ b/tests/shared/Tests.Shared/IntegrationTests/IntegrationTestFactory.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/IntegrationTests/ServiceCollectionExtensions.cs
+++ b/tests/shared/Tests.Shared/IntegrationTests/ServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/TestSeeds/AppInstanceData.cs
+++ b/tests/shared/Tests.Shared/TestSeeds/AppInstanceData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/TestSeeds/BaseSeed.cs
+++ b/tests/shared/Tests.Shared/TestSeeds/BaseSeed.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/TestSeeds/OfferData.cs
+++ b/tests/shared/Tests.Shared/TestSeeds/OfferData.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/TestSeeds/SeedExtensions.cs
+++ b/tests/shared/Tests.Shared/TestSeeds/SeedExtensions.cs
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2021,2022 BMW Group AG
- * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tests/shared/Tests.Shared/Tests.Shared.csproj
+++ b/tests/shared/Tests.Shared/Tests.Shared.csproj
@@ -1,6 +1,6 @@
 <!--
-- Copyright (c) 2021,2022 BMW Group AG
-- Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+- Copyright (c) 2021, 2023 BMW Group AG
+- Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.


### PR DESCRIPTION
update headers and header template for 2023
remove company specific information in header templates as migration to eclipse has been completed