### PR TITLE
chore: remove obsolete secrets directories and use default config sources

### DIFF
--- a/src/checklist/Checklist.Worker/Program.cs
+++ b/src/checklist/Checklist.Worker/Program.cs
@@ -32,12 +32,6 @@ try
 {
     Console.WriteLine("Building worker");
     var host = Host.CreateDefaultBuilder(args)
-     .ConfigureAppConfiguration(cfg =>
-     {
-         cfg
-          .AddEnvironmentVariables()
-          .AddUserSecrets(Assembly.GetExecutingAssembly());
-     })
      .ConfigureServices((hostContext, services) =>
       services
         .AddTransient<ChecklistExecutionService>()

--- a/src/checklist/Checklist.Worker/Properties/launchSettings.json
+++ b/src/checklist/Checklist.Worker/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Checklist.Worker": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/portalbackend/PortalBackend.Migrations/Program.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Program.cs
@@ -35,7 +35,6 @@ try
         .ConfigureAppConfiguration(cfg =>
         {
             cfg
-                .AddJsonFile("secrets/appsettings.json", true)
                 .AddEnvironmentVariables()
                 .AddUserSecrets(Assembly.GetExecutingAssembly());
         })

--- a/src/portalbackend/PortalBackend.Migrations/Program.cs
+++ b/src/portalbackend/PortalBackend.Migrations/Program.cs
@@ -32,12 +32,6 @@ Console.WriteLine("Starting process");
 try
 {
     var builder = Host.CreateDefaultBuilder(args)
-        .ConfigureAppConfiguration(cfg =>
-        {
-            cfg
-                .AddEnvironmentVariables()
-                .AddUserSecrets(Assembly.GetExecutingAssembly());
-        })
         .ConfigureServices((hostContext, services) =>
         {
             services.AddDbContext<PortalDbContext>(o =>

--- a/src/portalbackend/PortalBackend.Migrations/Properties/launchSettings.json
+++ b/src/portalbackend/PortalBackend.Migrations/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "PortalBackend.Migrations": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/portalbackend/PortalBackend.Migrations/secrets/appsettings.json
+++ b/src/portalbackend/PortalBackend.Migrations/secrets/appsettings.json
@@ -1,8 +1,0 @@
-{
-  "ConnectionStrings": {
-    "PortalDb": "Server=placeholder;Database=placeholder;Port=5432;User Id=placeholder;Password=placeholder;Ssl Mode=Disable;"
-  },
-  "Seeding":{
-    "TestDataEnvironments": []
-  }
-}

--- a/src/provisioning/Provisioning.Migrations/Program.cs
+++ b/src/provisioning/Provisioning.Migrations/Program.cs
@@ -31,12 +31,6 @@ Console.WriteLine("Starting process");
 try
 {
     var builder = Host.CreateDefaultBuilder(args)
-        .ConfigureAppConfiguration(cfg =>
-        {
-            cfg
-                .AddEnvironmentVariables()
-                .AddUserSecrets(Assembly.GetExecutingAssembly());
-        })
         .ConfigureServices((hostContext, services) =>
         {
             services.AddDbContext<ProvisioningDbContext>(o =>

--- a/src/provisioning/Provisioning.Migrations/Program.cs
+++ b/src/provisioning/Provisioning.Migrations/Program.cs
@@ -34,7 +34,6 @@ try
         .ConfigureAppConfiguration(cfg =>
         {
             cfg
-                .AddJsonFile("secrets/appsettings.json", true)
                 .AddEnvironmentVariables()
                 .AddUserSecrets(Assembly.GetExecutingAssembly());
         })

--- a/src/provisioning/Provisioning.Migrations/Properties/launchSettings.json
+++ b/src/provisioning/Provisioning.Migrations/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Provisioning.Migrations": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/provisioning/Provisioning.Migrations/secrets/appsettings.json
+++ b/src/provisioning/Provisioning.Migrations/secrets/appsettings.json
@@ -1,8 +1,0 @@
-{
-  "ConnectionStrings": {
-    "ProvisioningDB": "Server=devhost;Database=postgres;Port=5432;User Id=provisioning;Password=pwprovisioning;Ssl Mode=Disable;"
-  },
-  "Seeding":{
-    "TestDataEnvironments": []
-  }
-}


### PR DESCRIPTION
remove obsolete secrets directories
use default config sources with launchsettings for development https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-6.0#default-builder-settings
Ref: https://jira.catena-x.net/browse/CPLP-1617