### PR TITLE
ci: add externalsystems to checklist worker

### DIFF
--- a/.github/workflows/administration-service.yml
+++ b/.github/workflows/administration-service.yml
@@ -24,6 +24,7 @@ on:
     paths:
       # service and transitive paths
       - 'src/administration/**'
+      - 'src/externalsystems/**'
       - 'src/framework/**'
       - 'src/keycloak/**'
       - 'src/mailing/**'

--- a/.github/workflows/checklist-worker.yml
+++ b/.github/workflows/checklist-worker.yml
@@ -25,6 +25,7 @@ on:
       # service and transitive paths
       - 'src/checklist/Checklist.Worker/**'
       - 'src/checklist/Checklist.Library/**'
+      - 'src/externalsystems/**'
       - 'src/framework/**'
       - 'src/portalbackend/PortalBackend.PortalEntities/**'
       # workflow file


### PR DESCRIPTION
changes in the externalsystems path triggers the build of the checklist worker