### PR TITLE
feat(servicerelease): get agreementdata and consent

### DIFF
--- a/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServiceReleaseController.cs
@@ -55,7 +55,7 @@ public class ServiceReleaseController : ControllerBase
     /// <response code="200">Returns the Cpllection of agreement data</response>
     [HttpGet]
     [Route("agreementData")]
-    [Authorize(Roles = "edit_apps")]
+    [Authorize(Roles = "add_service_offering")]
     [ProducesResponseType(typeof(IAsyncEnumerable<AgreementDocumentData>), StatusCodes.Status200OK)]
     public IAsyncEnumerable<AgreementDocumentData> GetServiceAgreementDataAsync() =>
         _serviceReleaseBusinessLogic.GetServiceAgreementDataAsync();
@@ -101,7 +101,7 @@ public class ServiceReleaseController : ControllerBase
     /// <response code="403">User not associated with offer.</response>
     [HttpGet]
     [Route("consent/{serviceId}")]
-    [Authorize(Roles = "edit_apps")]
+    [Authorize(Roles = "add_service_offering")]
     [ProducesResponseType(typeof(OfferAgreementConsent), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]


### PR DESCRIPTION
changed the permission for end point api/services/servicerelease/agreementData
api/services/servicerelease/agreementData/consent/{serviceId} from edit_apps to add_service_offering
ref:-CPLP-2350 && 2294