### PR TITLE
feat!: move endpoints from service to serviceRelease

### DIFF
--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -38,14 +38,6 @@ public interface IServiceBusinessLogic
     Task<Pagination.Response<ServiceOverviewData>> GetAllActiveServicesAsync(int page, int size, ServiceOverviewSorting? sorting, ServiceTypeId? serviceTypeId);
 
     /// <summary>
-    /// Creates a new service offering
-    /// </summary>
-    /// <param name="data">The data to create the service offering</param>
-    /// <param name="iamUserId">the iamUser id</param>
-    /// <returns>The id of the newly created service</returns>
-    Task<Guid> CreateServiceOfferingAsync(ServiceOfferingData data, string iamUserId);
-
-    /// <summary>
     /// Adds a subscription to the given service
     /// </summary>
     /// <param name="serviceId">Id of the service the users company should be subscribed to</param>
@@ -95,14 +87,6 @@ public interface IServiceBusinessLogic
     Task<OfferAutoSetupResponseData> AutoSetupServiceAsync(OfferAutoSetupData data, string iamUserId);
 
     /// <summary>
-    /// Updates the given service
-    /// </summary>
-    /// <param name="serviceId">Id of the service to update</param>
-    /// <param name="data">Data of the updated entry</param>
-    /// <param name="iamUserId">Id of the current user</param>
-    Task UpdateServiceAsync(Guid serviceId, ServiceUpdateRequestData data, string iamUserId);
-
-    /// <summary>
     /// Retrieves subscription statuses of provided services of the provided user's company.
     /// </summary>
     /// <param name="page"></param>
@@ -112,40 +96,6 @@ public interface IServiceBusinessLogic
     /// <param name="statusId"></param>
     /// <returns>Pagination of user's company's provided service' statuses.</returns>
     Task<Pagination.Response<OfferCompanySubscriptionStatusData>> GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(int page, int size, string iamUserId, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId);
-
-    /// <summary>
-    /// Update app status and create notification
-    /// </summary>
-    /// <param name="serviceId">Id of the service that should be submitted</param>
-    /// <param name="iamUserId">Id of the iamUser</param>
-    Task SubmitServiceAsync(Guid serviceId, string iamUserId);
-
-    /// <summary>
-    /// Approve Service Status from IN_Review to Active
-    /// </summary>
-    /// <param name="appId"></param>
-    /// <param name="iamUserId"></param>
-    /// <returns></returns>
-    Task ApproveServiceRequestAsync(Guid appId, string iamUserId);
-
-    /// <summary>
-    /// Declines the service request
-    /// </summary>
-    /// <param name="serviceId">Id of the service</param>
-    /// <param name="iamUserId">Id of the iamUser</param>
-    /// <param name="data">The decline request data</param>
-    Task DeclineServiceRequestAsync(Guid serviceId, string iamUserId, OfferDeclineRequest data);
-
-    /// <summary>
-    /// Upload document for given company user for Service
-    /// </summary>
-    /// <param name="serviceId"></param>
-    /// <param name="documentTypeId"></param>
-    /// <param name="document"></param>
-    /// <param name="iamUserId"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task CreateServiceDocumentAsync(Guid serviceId, DocumentTypeId documentTypeId, IFormFile document, string iamUserId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get the document content by given Id for Service
@@ -166,5 +116,4 @@ public interface IServiceBusinessLogic
     /// <param name="offerName"></param>
     /// <param name="statusId"></param>
     Task<Pagination.Response<AllOfferStatusData>> GetCompanyProvidedServiceStatusDataAsync(int page, int size, string userId, OfferSorting? sorting, string? offerName, ServiceStatusIdFilter? statusId);
-
 }

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceReleaseBusinessLogic.cs
@@ -22,6 +22,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.BusinessLogic;
 
@@ -82,6 +83,56 @@ public interface IServiceReleaseBusinessLogic
     /// <param name="serviceName"></param>
     /// <param name="languageShortName"></param>
     Task<Pagination.Response<InReviewServiceData>> GetAllInReviewStatusServiceAsync(int page, int size, OfferSorting? sorting, string? serviceName, string? languageShortName);
+    
+    /// <summary>
+    /// Creates a new service offering
+    /// </summary>
+    /// <param name="data">The data to create the service offering</param>
+    /// <param name="iamUserId">the iamUser id</param>
+    /// <returns>The id of the newly created service</returns>
+    Task<Guid> CreateServiceOfferingAsync(ServiceOfferingData data, string iamUserId);
+
+    /// <summary>
+    /// Updates the given service
+    /// </summary>
+    /// <param name="serviceId">Id of the service to update</param>
+    /// <param name="data">Data of the updated entry</param>
+    /// <param name="iamUserId">Id of the current user</param>
+    Task UpdateServiceAsync(Guid serviceId, ServiceUpdateRequestData data, string iamUserId);
+
+    /// <summary>
+    /// Update app status and create notification
+    /// </summary>
+    /// <param name="serviceId">Id of the service that should be submitted</param>
+    /// <param name="iamUserId">Id of the iamUser</param>
+    Task SubmitServiceAsync(Guid serviceId, string iamUserId);
+
+    /// <summary>
+    /// Approve Service Status from IN_Review to Active
+    /// </summary>
+    /// <param name="appId"></param>
+    /// <param name="iamUserId"></param>
+    /// <returns></returns>
+    Task ApproveServiceRequestAsync(Guid appId, string iamUserId);
+
+    /// <summary>
+    /// Declines the service request
+    /// </summary>
+    /// <param name="serviceId">Id of the service</param>
+    /// <param name="iamUserId">Id of the iamUser</param>
+    /// <param name="data">The decline request data</param>
+    Task DeclineServiceRequestAsync(Guid serviceId, string iamUserId, OfferDeclineRequest data);
+
+    /// <summary>
+    /// Upload document for given company user for Service
+    /// </summary>
+    /// <param name="serviceId"></param>
+    /// <param name="documentTypeId"></param>
+    /// <param name="document"></param>
+    /// <param name="iamUserId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task CreateServiceDocumentAsync(Guid serviceId, DocumentTypeId documentTypeId, IFormFile document, string iamUserId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Delete the Service Document

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -73,10 +73,6 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
             _portalRepositories.GetInstance<IOfferRepository>().GetActiveServicesPaginationSource(sorting, serviceTypeId));
 
     /// <inheritdoc />
-    public Task<Guid> CreateServiceOfferingAsync(ServiceOfferingData data, string iamUserId) =>
-        _offerService.CreateServiceOfferingAsync(data, iamUserId, OfferTypeId.SERVICE);
-
-    /// <inheritdoc />
     public Task<Guid> AddServiceSubscription(Guid serviceId, IEnumerable<OfferAgreementConsentData> offerAgreementConsentData, string iamUserId, string accessToken) =>
         _offerSubscriptionService.AddOfferSubscriptionAsync(serviceId, offerAgreementConsentData, iamUserId, accessToken, _settings.ServiceManagerRoles, OfferTypeId.SERVICE, _settings.BasePortalAddress);
 
@@ -127,70 +123,6 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     /// <inheritdoc />
     public Task<OfferAutoSetupResponseData> AutoSetupServiceAsync(OfferAutoSetupData data, string iamUserId) =>
         _offerSetupService.AutoSetupOfferAsync(data, _settings.ITAdminRoles, iamUserId, OfferTypeId.SERVICE, _settings.UserManagementAddress);
-
-    /// <inheritdoc />
-    public async Task UpdateServiceAsync(Guid serviceId, ServiceUpdateRequestData data, string iamUserId)
-    {
-        var serviceData = await _portalRepositories
-            .GetInstance<IOfferRepository>()
-            .GetServiceUpdateData(serviceId, data.ServiceTypeIds, iamUserId)
-            .ConfigureAwait(false);
-        if (serviceData is null)
-        {
-            throw new NotFoundException($"Service {serviceId} does not exists");
-        }
-
-        if (serviceData.OfferState != OfferStatusId.CREATED)
-        {
-            throw new ConflictException($"Service in State {serviceData.OfferState} can't be updated");
-        }
-
-        if (!serviceData.IsUserOfProvider)
-        {
-            throw new ForbiddenException($"User {iamUserId} is not allowed to change the service.");
-        }
-
-        if (data.SalesManager.HasValue)
-        {
-            await _offerService.ValidateSalesManager(data.SalesManager.Value, iamUserId, _settings.SalesManagerRoles).ConfigureAwait(false);
-        }
-
-        var offerRepository = _portalRepositories.GetInstance<IOfferRepository>();
-        offerRepository.AttachAndModifyOffer(
-            serviceId,
-            offer =>
-            {
-                offer.Name = data.Title;
-                offer.SalesManagerId = data.SalesManager;
-                offer.ContactEmail = data.ContactEmail;
-                offer.MarketingUrl = data.ProviderUri;
-            },
-            offer =>
-            {
-                offer.SalesManagerId = serviceData.SalesManagerId;
-            });
-
-        _offerService.UpsertRemoveOfferDescription(serviceId, data.Descriptions, serviceData.Descriptions);
-        _offerService.CreateOrUpdateOfferLicense(serviceId, data.Price, serviceData.OfferLicense);
-        var newServiceTypes = data.ServiceTypeIds
-            .Except(serviceData.ServiceTypeIds.Where(x => x.IsMatch).Select(x => x.ServiceTypeId))
-            .Select(sti => (serviceId, sti, sti == ServiceTypeId.DATASPACE_SERVICE)); // TODO (PS): Must be refactored, customer needs to define whether the service needs a technical User
-        var serviceTypeIdsToRemove = serviceData.ServiceTypeIds
-            .Where(x => !x.IsMatch)
-            .Select(sti => (serviceId, sti.ServiceTypeId));
-        UpdateAssignedServiceTypes(
-            newServiceTypes, 
-            serviceTypeIdsToRemove,
-            offerRepository);
-
-        await _portalRepositories.SaveAsync().ConfigureAwait(false);
-    }
-    
-    private static void UpdateAssignedServiceTypes(IEnumerable<(Guid serviceId, ServiceTypeId serviceTypeId, bool technicalUserNeeded)> newServiceTypes, IEnumerable<(Guid serviceId, ServiceTypeId serviceTypeId)> serviceTypeIdsToRemove, IOfferRepository appRepository)
-    {
-        appRepository.AddServiceAssignedServiceTypes(newServiceTypes);
-        appRepository.RemoveServiceAssignedServiceTypes(serviceTypeIdsToRemove);
-    }
 
     /// <inheritdoc/>
     public Task<Pagination.Response<OfferCompanySubscriptionStatusData>> GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(int page, int size, string iamUserId, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId) =>

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -69,24 +69,6 @@ public class ServicesController : ControllerBase
         _serviceBusinessLogic.GetAllActiveServicesAsync(page, size, sorting, serviceTypeId);
 
     /// <summary>
-    /// Creates a new service offering.
-    /// </summary>
-    /// <param name="data">The data for the new service offering.</param>
-    /// <remarks>Example: POST: /api/services/addservice</remarks>
-    /// <response code="201">Returns the newly created service id.</response>
-    /// <response code="400">The given service offering data were invalid.</response>
-    [HttpPost]
-    [Route("addservice")]
-    [Authorize(Roles = "add_service_offering")]
-    [ProducesResponseType(typeof(OfferProviderResponse), StatusCodes.Status201Created)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public async Task<CreatedAtRouteResult> CreateServiceOffering([FromBody] ServiceOfferingData data)
-    {
-        var id = await this.WithIamUserId(iamUserId => _serviceBusinessLogic.CreateServiceOfferingAsync(data, iamUserId)).ConfigureAwait(false);
-        return CreatedAtRoute(nameof(ServiceReleaseController.GetServiceDetailsForStatusAsync), new { controller = "ServiceRelease", serviceId = id }, id);
-    }
-
-    /// <summary>
     /// Adds a new service subscription.
     /// </summary>
     /// <param name="serviceId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">Id for the service the user wants to subscribe to.</param>
@@ -183,31 +165,6 @@ public class ServicesController : ControllerBase
         => await this.WithIamUserId(iamUserId => _serviceBusinessLogic.AutoSetupServiceAsync(data, iamUserId));
 
     /// <summary>
-    /// Updates the service
-    /// </summary>
-    /// <param name="serviceId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">Id for the service to update.</param>
-    /// <param name="data">The request data to update the service</param>
-    /// <remarks>Example: PUT: /api/services/{serviceId}</remarks>
-    /// <response code="204">Service was successfully updated.</response>
-    /// <response code="400">Offer Subscription is not in state created or user is not in the same company.</response>
-    /// <response code="404">Offer Subscription not found.</response>
-    /// <response code="403">User don't have permission to change the service.</response>
-    /// <response code="409">Service is in inCorrect state</response>
-    [HttpPut]
-    [Route("{serviceId:guid}")]
-    [Authorize(Roles = "update_service_offering")]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public async Task<NoContentResult> UpdateService([FromRoute] Guid serviceId, [FromBody] ServiceUpdateRequestData data)
-    {
-        await this.WithIamUserId(iamUserId => _serviceBusinessLogic.UpdateServiceAsync(serviceId, data, iamUserId));
-        return NoContent();
-    }
-    
-    /// <summary>
     /// Retrieves subscription statuses of provided services of the currently logged in user's company.
     /// </summary>
     /// <remarks>Example: GET: /api/services/provided/subscription-status</remarks>
@@ -220,107 +177,6 @@ public class ServicesController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
     public Task<Pagination.Response<OfferCompanySubscriptionStatusData>> GetCompanyProvidedServiceSubscriptionStatusesForCurrentUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15, [FromQuery] SubscriptionStatusSorting? sorting = null, [FromQuery] OfferSubscriptionStatusId? statusId = null) =>
         this.WithIamUserId(userId => _serviceBusinessLogic.GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(page, size, userId, sorting, statusId));
-
-    /// <summary>
-    /// Submit an Service for release
-    /// </summary>
-    /// <param name="serviceId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">ID of the service.</param>
-    /// <remarks>Example: PUT: /api/services/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/submit</remarks>
-    /// <response code="204">The service was successfully submitted for release.</response>
-    /// <response code="400">Either the sub claim is empty/invalid, user does not exist or the subscription might not have the correct status or the companyID is incorrect.</response>
-    /// <response code="404">service does not exist.</response>
-    [HttpPut]
-    [Route("{serviceId:guid}/submit")]
-    [Authorize(Roles = "add_service_offering")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public async Task<NoContentResult> SubmitService([FromRoute] Guid serviceId)
-    {
-        await this.WithIamUserId(userId => _serviceBusinessLogic.SubmitServiceAsync(serviceId, userId)).ConfigureAwait(false);
-        return NoContent();
-    }
-
-    /// <summary>
-    /// Approve Service to change status from IN_REVIEW to Active and create notification
-    /// </summary>
-    /// <param name="serviceId"></param>
-    /// <remarks>Example: PUT: /api/services/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/approveService</remarks>
-    /// <response code="204">The service was successfully submitted to Active State.</response>
-    /// <response code="409">Service is in InCorrect Status</response>
-    /// <response code="404">service does not exist.</response>
-    /// <response code="500">Internal server error</response>
-    [HttpPut]
-    [Route("{serviceId}/approveService")]
-    [Authorize(Roles = "approve_service_release")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
-    public async Task<NoContentResult> ApproveServiceRequest([FromRoute] Guid serviceId)
-    {
-        await this.WithIamUserId(userId => _serviceBusinessLogic.ApproveServiceRequestAsync(serviceId, userId)).ConfigureAwait(false);
-        return NoContent();
-    }
-
-    /// <summary>
-    /// Declines the service request
-    /// </summary>
-    /// <param name="serviceId" example="D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645">Id of the service that should be declined</param>
-    /// <param name="data">the data of the decline request</param>
-    /// <remarks>Example: PUT: /api/services/D3B1ECA2-6148-4008-9E6C-C1C2AEA5C645/decline</remarks>
-    /// <response code="204">NoContent.</response>
-    /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
-    /// <response code="404">If service does not exists.</response>
-    /// <response code="403">User doest not have permission to change</response>
-    /// <response code="409">Offer Type is in inCorrect state.</response>
-    /// <response code="500">Internal Server Error.</response>
-    [HttpPut]
-    [Route("{serviceId:guid}/declineService")]
-    [Authorize(Roles = "decline_service_release")]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status500InternalServerError)]
-    public async Task<NoContentResult> DeclineServiceRequest([FromRoute] Guid serviceId, [FromBody] OfferDeclineRequest data)
-    {
-        await this.WithIamUserId(userId => _serviceBusinessLogic.DeclineServiceRequestAsync(serviceId, userId, data)).ConfigureAwait(false);
-        return NoContent();
-    }
-
-    /// <summary>
-    /// Upload document for active service in the marketplace for given serviceId for same company as user
-    /// </summary>
-    /// <param name="serviceId"></param>
-    /// <param name="documentTypeId"></param>
-    /// <param name="document"></param>
-    /// <param name="cancellationToken"></param>
-    /// <remarks>Example: PUT: /api/services/updateservicedoc/{serviceId}/documentType/{documentTypeId}/documents</remarks>
-    /// <response code="204">Successfully uploaded the document</response>
-    /// <response code="400">If sub claim is empty/invalid or user does not exist, or any other parameters are invalid.</response>
-    /// <response code="404">service does not exist.</response>
-    /// <response code="403">The user is not assigned with the service.</response>
-    /// <response code="415">Only PDF files are supported.</response>
-    /// <response code="409">Offer is in inCorrect State.</response>
-    [HttpPut]
-    [Route("updateservicedoc/{serviceId}/documentType/{documentTypeId}/documents")]
-    [Authorize(Roles = "add_service_offering")]
-    [Consumes("multipart/form-data")]
-    [RequestFormLimits(ValueLengthLimit = 819200, MultipartBodyLengthLimit = 819200)]
-    [ProducesResponseType(typeof(NoContentResult), StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status415UnsupportedMediaType)]
-    public async Task<NoContentResult> UpdateServiceDocumentAsync([FromRoute] Guid serviceId, [FromRoute] DocumentTypeId documentTypeId, [FromForm(Name = "document")] IFormFile document, CancellationToken cancellationToken)
-    {
-        await this.WithIamUserId(iamUserId => _serviceBusinessLogic.CreateServiceDocumentAsync(serviceId, documentTypeId, document, iamUserId, cancellationToken));
-        return NoContent();
-    }
 
     /// <summary>
     /// Retrieve Document Content for Service by ID

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceReleaseBusinessLogicTest.cs
@@ -34,11 +34,20 @@ using Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 using Microsoft.Extensions.Options;
 using Xunit;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.Tests.BusinessLogic;
 
 public class ServiceReleaseBusinessLogicTest
 {
+    private readonly Guid _notExistingServiceId = Guid.NewGuid();
+    private readonly Guid _companyUserId = Guid.NewGuid();
+    private readonly Guid _companyUserCompanyId = Guid.NewGuid();
+    private readonly Guid _existingServiceId = new("9aae7a3b-b188-4a42-b46b-fb2ea5f47661");
+    private readonly Guid _activeServiceId = Guid.NewGuid();
+    private readonly Guid _differentCompanyServiceId = Guid.NewGuid();
+    private readonly string _iamUserId = Guid.NewGuid().ToString();
     private readonly IFixture _fixture;
     private readonly IOfferRepository _offerRepository;
     private readonly IPortalRepositories _portalRepositories;
@@ -335,6 +344,240 @@ public class ServiceReleaseBusinessLogicTest
     }
 
     #endregion
+
+    #region Create Service
+
+    [Fact]
+    public async Task CreateServiceOffering_WithValidDataAndEmptyDescriptions_ReturnsCorrectDetails()
+    {
+        // Arrange
+        var serviceId = Guid.NewGuid();
+        var offerService = A.Fake<IOfferService>();
+        _fixture.Inject(offerService);
+        A.CallTo(() => offerService.CreateServiceOfferingAsync(A<ServiceOfferingData>._, A<string>._, A<OfferTypeId>._)).ReturnsLazily(() => serviceId);
+        var sut = _fixture.Create<ServiceReleaseBusinessLogic>();
+
+        // Act
+        var result = await sut.CreateServiceOfferingAsync(new ServiceOfferingData("Newest Service", "42", "mail@test.de", _companyUserId, new List<LocalizedDescription>(), new List<ServiceTypeId>(), null), _iamUserId);
+
+        // Assert
+        result.Should().Be(serviceId);
+    }
+
+    #endregion
+
+    #region UpdateServiceAsync
+    
+    [Fact]
+    public async Task UpdateServiceAsync_WithoutService_ThrowsException()
+    {
+        // Arrange
+        SetupUpdateService();
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123","test@email.com", Guid.NewGuid(), null);
+        var settings = new ServiceSettings();
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(settings));
+     
+        // Act
+        async Task Act() => await sut.UpdateServiceAsync(_notExistingServiceId, data, _iamUserId).ConfigureAwait(false);
+
+        // Assert
+        var error = await Assert.ThrowsAsync<NotFoundException>(Act).ConfigureAwait(false);
+        error.Message.Should().Be($"Service {_notExistingServiceId} does not exists");
+    }
+    
+    [Fact]
+    public async Task UpdateServiceAsync_WithActiveService_ThrowsException()
+    {
+        // Arrange
+        SetupUpdateService();
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123","test@email.com", Guid.NewGuid(), null);
+        var settings = new ServiceSettings();
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(settings));
+     
+        // Act
+        async Task Act() => await sut.UpdateServiceAsync(_activeServiceId, data, _iamUserId).ConfigureAwait(false);
+
+        // Assert
+        var error = await Assert.ThrowsAsync<ConflictException>(Act).ConfigureAwait(false);
+        error.Message.Should().Be("Service in State ACTIVE can't be updated");
+    }
+
+    [Fact]
+    public async Task UpdateServiceAsync_WithInvalidUser_ThrowsException()
+    {
+        // Arrange
+        SetupUpdateService();
+        var data = new ServiceUpdateRequestData("test", new List<LocalizedDescription>(), new List<ServiceTypeId>(), "123","test@email.com", Guid.NewGuid(), null);
+        var settings = new ServiceSettings();
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(settings));
+
+        // Act
+        async Task Act() => await sut.UpdateServiceAsync(_differentCompanyServiceId, data, _iamUserId).ConfigureAwait(false);
+
+        // Assert
+        var error = await Assert.ThrowsAsync<ForbiddenException>(Act).ConfigureAwait(false);
+        error.Message.Should().Be($"User {_iamUserId} is not allowed to change the service.");
+    }
+
+    [Fact]
+    public async Task UpdateServiceAsync_WithValidData_ReturnsExpected()
+    {
+        // Arrange
+        SetupUpdateService();
+        var data = new ServiceUpdateRequestData(
+            "test", 
+            new List<LocalizedDescription>
+            {
+                new("de", "Long description", "desc") 
+            }, 
+            new List<ServiceTypeId>
+            {
+                ServiceTypeId.CONSULTANCE_SERVICE
+            }, 
+            "43",
+            "test@email.com",
+            _companyUserId,
+            null);
+        var settings = new ServiceSettings
+        {
+            SalesManagerRoles = new Dictionary<string, IEnumerable<string>>
+            {
+                { "portal", new[] { "SalesManager" } }
+            }
+        };
+        var existingOffer = _fixture.Create<Offer>();
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(A<Guid>._, A<Action<Offer>>._, A<Action<Offer>>._))
+            .Invokes((Guid _, Action<Offer> setOptionalParameters, Action<Offer>? initializeParameters) =>
+            {
+                initializeParameters?.Invoke(existingOffer);
+                setOptionalParameters(existingOffer);
+            });
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(settings));
+
+        // Act
+        await sut.UpdateServiceAsync(_existingServiceId, data, _iamUserId).ConfigureAwait(false);
+        
+        // Assert
+        A.CallTo(() => _offerRepository.AttachAndModifyOffer(A<Guid>._, A<Action<Offer>>._, A<Action<Offer>>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerService.UpsertRemoveOfferDescription(A<Guid>._, A<IEnumerable<LocalizedDescription>>._, A<IEnumerable<LocalizedDescription>>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerService.CreateOrUpdateOfferLicense(A<Guid>._, A<string>._, A<(Guid offerLicenseId, string price, bool assignedToMultipleOffers)>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.AddServiceAssignedServiceTypes(A<IEnumerable<(Guid serviceId, ServiceTypeId serviceTypeId, bool technicalUserNeeded)>>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => _offerRepository.RemoveServiceAssignedServiceTypes(A<IEnumerable<(Guid serviceId, ServiceTypeId serviceTypeId)>>._))
+            .MustHaveHappenedOnceExactly();
+        existingOffer.Name.Should().Be("test");
+    }
+
+    #endregion
+    
+    #region SubmitServiceAsync
+
+    [Fact]
+    public async Task SubmitServiceAsync_CallsOfferService()
+    {
+        // Arrange
+        var sut = new ServiceReleaseBusinessLogic(null!, _offerService, _options);
+
+        // Act
+        await sut.SubmitServiceAsync(_existingServiceId, _iamUserId).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => 
+                _offerService.SubmitServiceAsync(
+                    _existingServiceId,
+                    _iamUserId,
+                    OfferTypeId.SERVICE,
+                    A<IEnumerable<NotificationTypeId>>._,
+                    A<IDictionary<string, IEnumerable<string>>>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+    
+    #region DeclineServiceRequest
+    
+    [Fact]
+    public async Task DeclineServiceRequestAsync_CallsExpected()
+    {
+        // Arrange
+        var data = new OfferDeclineRequest("Just a test");
+        var settings = new ServiceSettings
+        {
+            ServiceManagerRoles = _fixture.Create<Dictionary<string, IEnumerable<string>>>(),
+            BasePortalAddress = "test"
+        };
+        var sut = new ServiceReleaseBusinessLogic(null!, _offerService, Options.Create(settings));
+     
+        // Act
+        await sut.DeclineServiceRequestAsync(_existingServiceId, _iamUserId, data).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _offerService.DeclineOfferAsync(_existingServiceId, _iamUserId, data,
+            OfferTypeId.SERVICE, NotificationTypeId.SERVICE_RELEASE_REJECTION,
+            A<IDictionary<string, IEnumerable<string>>>._, A<string>._,
+            A<IEnumerable<NotificationTypeId>>._, A<IDictionary<string, IEnumerable<string>>>._)).MustHaveHappenedOnceExactly();
+    }
+    
+    #endregion
+
+    #region Create Service Document
+    [Fact]
+    public async Task CreateServiceDocument_ExecutesSuccessfully()
+    {
+        // Arrange
+        var serviceId = _fixture.Create<Guid>();
+        var file = FormFileHelper.GetFormFile("this is just a test", "superFile.pdf", "application/pdf");
+        var settings = new ServiceSettings()
+        {
+            ContentTypeSettings = new[] { "application/pdf" },
+            DocumentTypeIds = new[] { DocumentTypeId.ADDITIONAL_DETAILS }
+        };
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(settings));
+
+        // Act
+        await sut.CreateServiceDocumentAsync(serviceId, DocumentTypeId.ADDITIONAL_DETAILS, file, _iamUserId, CancellationToken.None).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _offerService.UploadDocumentAsync(serviceId, DocumentTypeId.ADDITIONAL_DETAILS, file, _iamUserId, OfferTypeId.SERVICE, settings.DocumentTypeIds, settings.ContentTypeSettings, CancellationToken.None)).MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
+    #region ApproveServiceRequestAsync
+
+    [Fact]
+    public async Task ApproveServiceRequestAsync_WithValid_CallsExpected()
+    {
+        // Arrange
+        var appId = Guid.NewGuid();
+        var sut = new ServiceReleaseBusinessLogic(_portalRepositories, _offerService, Options.Create(new ServiceSettings()));
+        
+        // Act
+        await sut.ApproveServiceRequestAsync(appId, _iamUserId).ConfigureAwait(false);
+        
+        // Assert
+        A.CallTo(() => _offerService.ApproveOfferRequestAsync(appId, _iamUserId, OfferTypeId.SERVICE,
+            A<IEnumerable<NotificationTypeId>>._, A<IDictionary<string, IEnumerable<string>>>._,
+            A<IEnumerable<NotificationTypeId>>._, A<IDictionary<string, IEnumerable<string>>>._)).MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
+    private void SetupUpdateService()
+    {
+        A.CallTo(() => _offerRepository.GetServiceUpdateData(_notExistingServiceId, A<IEnumerable<ServiceTypeId>>._, _iamUserId))
+            .ReturnsLazily(() => (ServiceUpdateData?)null);
+        A.CallTo(() => _offerRepository.GetServiceUpdateData(_activeServiceId, A<IEnumerable<ServiceTypeId>>._, _iamUserId))
+            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.ACTIVE, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), new ValueTuple<Guid, string, bool>(), Array.Empty<LocalizedDescription>(), null));
+        A.CallTo(() => _offerRepository.GetServiceUpdateData(_differentCompanyServiceId, A<IEnumerable<ServiceTypeId>>._, _iamUserId))
+            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.CREATED, false, Array.Empty<(ServiceTypeId serviceTypeId, bool IsMatch)>(), new ValueTuple<Guid, string, bool>(), Array.Empty<LocalizedDescription>(), null));
+        A.CallTo(() => _offerRepository.GetServiceUpdateData(_existingServiceId, A<IEnumerable<ServiceTypeId>>._, _iamUserId))
+            .ReturnsLazily(() => new ServiceUpdateData(OfferStatusId.CREATED, true, Enumerable.Repeat(new ValueTuple<ServiceTypeId, bool>(ServiceTypeId.DATASPACE_SERVICE, false), 1), new ValueTuple<Guid, string, bool>(Guid.NewGuid(), "123", false), Array.Empty<LocalizedDescription>(), Guid.NewGuid()));
+        A.CallTo(() => _offerService.ValidateSalesManager(A<Guid>._, A<string>._, A<IDictionary<string, IEnumerable<string>>>._)).Returns(_companyUserCompanyId);
+    }
 
     private void SetupRepositories()
     {

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -54,24 +54,6 @@ public class ServiceControllerTest
     }
 
     [Fact]
-    public async Task CreateServiceOffering_ReturnsExpectedId()
-    {
-        //Arrange
-        var id = new Guid("d90995fe-1241-4b8d-9f5c-f3909acc6383");
-        var serviceOfferingData = _fixture.Create<ServiceOfferingData>();
-        A.CallTo(() => _logic.CreateServiceOfferingAsync(A<ServiceOfferingData>._, IamUserId))
-            .Returns(id);
-
-        //Act
-        var result = await this._controller.CreateServiceOffering(serviceOfferingData).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.CreateServiceOfferingAsync(serviceOfferingData, IamUserId)).MustHaveHappenedOnceExactly();
-        Assert.IsType<CreatedAtRouteResult>(result);
-        result.Value.Should().Be(id);
-    }
-
-    [Fact]
     public async Task GetAllActiveServicesAsync_ReturnsExpectedId()
     {
         //Arrange
@@ -197,24 +179,7 @@ public class ServiceControllerTest
         Assert.IsType<OfferAutoSetupResponseData>(result);
         result.Should().Be(responseData);
     }
-        
-    [Fact]
-    public async Task UpdateService_ReturnsExpected()
-    {
-        //Arrange
-        var serviceId = _fixture.Create<Guid>();
-        var data = _fixture.Create<ServiceUpdateRequestData>();
-        A.CallTo(() => _logic.UpdateServiceAsync(A<Guid>._, A<ServiceUpdateRequestData>._, A<string>.That.Matches(x => x== IamUserId)))
-            .Returns(Task.CompletedTask);
-
-        //Act
-        var result = await this._controller.UpdateService(serviceId, data).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.UpdateServiceAsync(serviceId, data, IamUserId)).MustHaveHappenedOnceExactly();
-        Assert.IsType<NoContentResult>(result);
-    }
-    
+      
     [Fact]
     public async Task GetCompanyProvidedServiceSubscriptionStatusesForCurrentUserAsync_ReturnsExpectedCount()
     {
@@ -231,56 +196,7 @@ public class ServiceControllerTest
         A.CallTo(() => _logic.GetCompanyProvidedServiceSubscriptionStatusesForUserAsync(0, 15, IamUserId, null, null)).MustHaveHappenedOnceExactly();
         result.Content.Should().HaveCount(5);
     }
-    
-    [Fact]
-    public async Task SubmitService_ReturnsExpectedCount()
-    {
-        //Arrange
-        A.CallTo(() => _logic.SubmitServiceAsync(A<Guid>._, A<string>._))
-            .ReturnsLazily(() => Task.CompletedTask);
 
-
-        //Act
-        var result = await this._controller.SubmitService(ServiceId).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.SubmitServiceAsync(ServiceId, IamUserId)).MustHaveHappenedOnceExactly();
-    }
-        
-    [Fact]
-    public async Task DeclineServiceRequest_ReturnsNoContent()
-    {
-        //Arrange
-        var serviceId = _fixture.Create<Guid>();
-        var data = new OfferDeclineRequest("Just a test");
-        A.CallTo(() => _logic.DeclineServiceRequestAsync(A<Guid>._, A<string>._, A<OfferDeclineRequest>._))
-            .ReturnsLazily(() => Task.CompletedTask);
-
-        //Act
-        var result = await this._controller.DeclineServiceRequest(serviceId, data).ConfigureAwait(false);
-
-        //Assert
-        A.CallTo(() => _logic.DeclineServiceRequestAsync(serviceId, IamUserId, data)).MustHaveHappenedOnceExactly();
-        result.Should().BeOfType<NoContentResult>();
-    }
-
-    [Fact]
-    public async Task UpdateServiceDocumentAsync_CallExpected()
-    {
-        // Arrange
-        var serviceId = _fixture.Create<Guid>();
-        var file = FormFileHelper.GetFormFile("this is just a test", "superFile.pdf", "application/pdf");
-        A.CallTo(() => _logic.CreateServiceDocumentAsync(A<Guid>._,
-            A<DocumentTypeId>._, A<IFormFile>._, A<string>._, CancellationToken.None))
-            .ReturnsLazily(() => Task.CompletedTask);
-        
-        // Act
-        await this._controller.UpdateServiceDocumentAsync(serviceId,DocumentTypeId.ADDITIONAL_DETAILS,file,CancellationToken.None).ConfigureAwait(false);
-
-        // Assert
-        A.CallTo(() => _logic.CreateServiceDocumentAsync(serviceId,
-            DocumentTypeId.ADDITIONAL_DETAILS, file, IamUserId, CancellationToken.None)).MustHaveHappened();
-    }
     [Fact]
     public async Task GetServiceDocumentContentAsync_ReturnsExpected()
     {

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
@@ -21,6 +21,7 @@
 using AutoFixture;
 using FakeItEasy;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
@@ -29,6 +30,7 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.BusinessLogic;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
+using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
 using Xunit;
 
@@ -36,8 +38,9 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.Tests.Controllers
 
 public class ServiceReleaseControllerTest
 {
-    private static readonly string IamUserId = "4C1A6851-D4E7-4E10-A011-3732CD045E8A";
-    private readonly string _accessToken = "THISISTHEACCESSTOKEN";
+    private const string IamUserId = "4C1A6851-D4E7-4E10-A011-3732CD045E8A";
+    private const string AccessToken = "THISISTHEACCESSTOKEN";
+    private static readonly Guid ServiceId = new("4C1A6851-D4E7-4E10-A011-3732CD045453");
     private readonly IFixture _fixture;
     private readonly IServiceReleaseBusinessLogic _logic;
     private readonly ServiceReleaseController _controller;
@@ -46,7 +49,7 @@ public class ServiceReleaseControllerTest
         _fixture = new Fixture();
         _logic = A.Fake<IServiceReleaseBusinessLogic>();
         this._controller = new ServiceReleaseController(_logic);
-        _controller.AddControllerContextWithClaimAndBearer(IamUserId, _accessToken);
+        _controller.AddControllerContextWithClaimAndBearer(IamUserId, AccessToken);
     }
 
     [Fact]
@@ -185,5 +188,89 @@ public class ServiceReleaseControllerTest
         Assert.IsType<NoContentResult>(result);
         A.CallTo(() => _logic.DeleteServiceDocumentsAsync(documentId, IamUserId))
             .MustHaveHappenedOnceExactly();
+    }
+    
+    [Fact]
+    public async Task CreateServiceOffering_ReturnsExpectedId()
+    {
+        //Arrange
+        var id = new Guid("d90995fe-1241-4b8d-9f5c-f3909acc6383");
+        var serviceOfferingData = _fixture.Create<ServiceOfferingData>();
+        A.CallTo(() => _logic.CreateServiceOfferingAsync(A<ServiceOfferingData>._, IamUserId))
+            .Returns(id);
+
+        //Act
+        var result = await this._controller.CreateServiceOffering(serviceOfferingData).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.CreateServiceOfferingAsync(serviceOfferingData, IamUserId)).MustHaveHappenedOnceExactly();
+        Assert.IsType<CreatedAtRouteResult>(result);
+        result.Value.Should().Be(id);
+    }
+ 
+    [Fact]
+    public async Task UpdateService_ReturnsExpected()
+    {
+        //Arrange
+        var serviceId = _fixture.Create<Guid>();
+        var data = _fixture.Create<ServiceUpdateRequestData>();
+        A.CallTo(() => _logic.UpdateServiceAsync(A<Guid>._, A<ServiceUpdateRequestData>._, A<string>.That.Matches(x => x== IamUserId)))
+            .Returns(Task.CompletedTask);
+
+        //Act
+        var result = await this._controller.UpdateService(serviceId, data).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.UpdateServiceAsync(serviceId, data, IamUserId)).MustHaveHappenedOnceExactly();
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task SubmitService_ReturnsExpectedCount()
+    {
+        //Arrange
+        A.CallTo(() => _logic.SubmitServiceAsync(A<Guid>._, A<string>._))
+            .ReturnsLazily(() => Task.CompletedTask);
+
+        //Act
+        await this._controller.SubmitService(ServiceId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.SubmitServiceAsync(ServiceId, IamUserId)).MustHaveHappenedOnceExactly();
+    }
+        
+    [Fact]
+    public async Task DeclineServiceRequest_ReturnsNoContent()
+    {
+        //Arrange
+        var serviceId = _fixture.Create<Guid>();
+        var data = new OfferDeclineRequest("Just a test");
+        A.CallTo(() => _logic.DeclineServiceRequestAsync(A<Guid>._, A<string>._, A<OfferDeclineRequest>._))
+            .ReturnsLazily(() => Task.CompletedTask);
+
+        //Act
+        var result = await this._controller.DeclineServiceRequest(serviceId, data).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.DeclineServiceRequestAsync(serviceId, IamUserId, data)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task UpdateServiceDocumentAsync_CallExpected()
+    {
+        // Arrange
+        var serviceId = _fixture.Create<Guid>();
+        var file = FormFileHelper.GetFormFile("this is just a test", "superFile.pdf", "application/pdf");
+        A.CallTo(() => _logic.CreateServiceDocumentAsync(A<Guid>._,
+            A<DocumentTypeId>._, A<IFormFile>._, A<string>._, CancellationToken.None))
+            .ReturnsLazily(() => Task.CompletedTask);
+        
+        // Act
+        await this._controller.UpdateServiceDocumentAsync(serviceId,DocumentTypeId.ADDITIONAL_DETAILS,file,CancellationToken.None).ConfigureAwait(false);
+
+        // Assert
+        A.CallTo(() => _logic.CreateServiceDocumentAsync(serviceId,
+            DocumentTypeId.ADDITIONAL_DETAILS, file, IamUserId, CancellationToken.None)).MustHaveHappened();
     }
 }

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceReleaseControllerTest.cs
@@ -238,7 +238,22 @@ public class ServiceReleaseControllerTest
         //Assert
         A.CallTo(() => _logic.SubmitServiceAsync(ServiceId, IamUserId)).MustHaveHappenedOnceExactly();
     }
-        
+    
+
+    [Fact]
+    public async Task ApproveServiceRequest_ReturnsNoContent()
+    {
+        //Arrange
+        var serviceId = _fixture.Create<Guid>();
+
+        //Act
+        var result = await this._controller.ApproveServiceRequest(serviceId).ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.ApproveServiceRequestAsync(serviceId, IamUserId)).MustHaveHappenedOnceExactly();
+        result.Should().BeOfType<NoContentResult>();
+    }
+
     [Fact]
     public async Task DeclineServiceRequest_ReturnsNoContent()
     {

--- a/tests/marketplace/Services.Service.Tests/Services.Service.Tests.csproj
+++ b/tests/marketplace/Services.Service.Tests/Services.Service.Tests.csproj
@@ -22,6 +22,7 @@
 
     <PropertyGroup>
         <AssemblyName>Org.Eclipse.TractusX.Portal.Backend.Services.Service.Tests</AssemblyName>
+        <RootNamespace>Org.Eclipse.TractusX.Portal.Backend.Services.Service.Tests</RootNamespace>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
the following endpoints have been moved to servicesRelease
POST: /api/services/addservice
PUT: /api/services/{serviceId}
PUT: /api/services/{serviceId}/submit
PUT: /api/services/{serviceId}/approveService
PUT: /api/services/{serviceId}/declineService
PUT: /api/services/updateservicedoc/{serviceId}/documentType/{documentTypeId}/documents

Refs: CPLP-2475
BREAKING CHANGES: Endpoints have been moved