### PR TITLE
feat(connector): add additional filter to managed endpoint

### DIFF
--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/ConnectorsRepository.cs
@@ -54,7 +54,8 @@ public class ConnectorsRepository : IConnectorsRepository
             take,
             _context.Connectors.AsNoTracking()
                 .Where(c => c.Host!.CompanyUsers.Any(cu => cu.IamUser!.UserEntityId == iamUserId) &&
-                            c.StatusId != ConnectorStatusId.INACTIVE)
+                            c.StatusId != ConnectorStatusId.INACTIVE &&
+                            c.TypeId == ConnectorTypeId.CONNECTOR_AS_A_SERVICE)
                 .GroupBy(c => c.HostId),
             connectors => connectors.OrderByDescending(connector => connector.Name),
             c => new ManagedConnectorData(

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/ConnectorRepositoryTests.cs
@@ -332,7 +332,8 @@ public class ConnectorRepositoryTests : IAssemblyFixture<TestDbFixture>
 
         // Assert
         result.Should().NotBeNull();
-        result!.Count.Should().Be(2);
+        result!.Count.Should().Be(1);
+        result.Data.Should().ContainSingle().Which.Name.Should().Be("Test Connector 3");
     }
 
     [Fact]

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/Seeder/Data/connectors.test.json
@@ -25,7 +25,7 @@
   },
   {
     "id": "7e86a0b8-6903-496b-96d1-0ef508206839",
-    "name": "Test Connector 1",
+    "name": "Test Connector 2",
     "connector_url": "www.google.de",
     "type_id": 1,
     "status_id": 1,
@@ -33,6 +33,18 @@
     "host_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
     "location_id": "DE",
     "self_description_document_id": "e020787d-1e04-4c0b-9c06-bd1cd44724b3",
+    "daps_registration_successful": null
+  },
+  {
+    "id": "7e86a0b8-6903-496b-96d1-0ef508206838",
+    "name": "Test Connector 3",
+    "connector_url": "www.google.de",
+    "type_id": 2,
+    "status_id": 1,
+    "provider_id": "41fd2ab8-71cd-4546-9bef-a388d91b2542",
+    "host_id": "2dc4249f-b5ca-4d42-bef1-7a7a950a4f87",
+    "location_id": "DE",
+    "self_description_document_id": null,
     "daps_registration_successful": null
   }
 ]


### PR DESCRIPTION
add filter for type equals CONNECTOR_AS_A_SERVICE to the /api/administration/connectors/managed endpoint

Refs: CPLP-2554