### PR TITLE
bugfix(healthchecks): fix npe when requireHttpsMetadata is true

### DIFF
--- a/src/framework/Framework.Web/JwtBearerConfigurationHealthCheck.cs
+++ b/src/framework/Framework.Web/JwtBearerConfigurationHealthCheck.cs
@@ -40,12 +40,14 @@ public class JwtBearerConfigurationHealthCheck : IHealthCheck
                 ServerCertificateCustomValidationCallback = (_,_,_,_) => true
             };
         }
-        _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-            options.MetadataAddress,
-            new OpenIdConnectConfigurationRetriever(),
-            options.BackchannelHttpHandler == null
-                ? null
-                : new HttpClient(options.BackchannelHttpHandler));
+        _configurationManager = options.BackchannelHttpHandler == null
+            ? new ConfigurationManager<OpenIdConnectConfiguration>(
+                options.MetadataAddress,
+                new OpenIdConnectConfigurationRetriever())
+            : new ConfigurationManager<OpenIdConnectConfiguration>(
+                options.MetadataAddress,
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpClient(options.BackchannelHttpHandler));
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(


### PR DESCRIPTION
* fix NullpointerException on non-development environments that have RequireHttpsMetadata set to true
Refs: CPLP-2567