### PR TITLE
chore: run only on PR if same base repo

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,9 +24,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+
 jobs:
   build:
     name: Build
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Why
due to issue 'Sonar cannot be run on PR from a fork' https://community.sonarsource.com/t/sonar-cannot-be-run-on-pr-from-a-fork/69229
serves preparation for working mode in tractusx, as this workflow otherwise just fails when a PR against tractusx is raised, in this way it is at least skipped.
tested successfully with https://github.com/eclipse-tractusx/portal-backend/pull/26.