### PR TITLE
feat(subscription): change offer status to offer subscription status

### DIFF
--- a/src/marketplace/Offers.Library/Models/OfferSubscriptionDetailData.cs
+++ b/src/marketplace/Offers.Library/Models/OfferSubscriptionDetailData.cs
@@ -27,7 +27,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 /// Detail data for a offer subscription
 /// </summary>
 /// <param name="Id">Id of the Offer</param>
-/// <param name="OfferStatus">Status of the offer</param>
+/// <param name="OfferSubscriptionStatus">Status of the offer subscription</param>
 /// <param name="Name">Name of the Offer</param>
 /// <param name="Customer">Name of the company subscribing the offer</param>
 /// <param name="Bpn">When called from /provider bpn of the company subscribing the offer, otherwise the provider company's bpn</param>
@@ -35,7 +35,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 /// <param name="TechnicalUserData">Information about the technical user</param>
 public record ProviderSubscriptionDetailData (
     Guid Id,
-    OfferStatusId OfferStatus,
+    OfferSubscriptionStatusId OfferSubscriptionStatus,
     string? Name,
     string Customer,
     string? Bpn,
@@ -47,14 +47,14 @@ public record ProviderSubscriptionDetailData (
 /// Detail data for a offer subscription
 /// </summary>
 /// <param name="Id">Id of the Offer</param>
-/// <param name="OfferStatus">Status of the offer</param>
+/// <param name="OfferSubscriptionStatus">Status of the offer subscription</param>
 /// <param name="Name">Name of the Offer</param>
 /// <param name="Provider">The provider company's name</param>
 /// <param name="Contact">When called from /provider the company admins of the subscribing company, otherwise the salesmanagers of the offer provider</param>
 /// <param name="TechnicalUserData">Information about the technical user</param>
 public record SubscriberSubscriptionDetailData (
     Guid Id,
-    OfferStatusId OfferStatus,
+    OfferSubscriptionStatusId OfferSubscriptionStatus,
     string? Name,
     string Provider,
     IEnumerable<string> Contact,

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -838,7 +838,7 @@ public class OfferService : IOfferService
         var details = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, iamUserId, offerTypeId, contactUserRoles, OfferCompanyRole.Provider);
         return new ProviderSubscriptionDetailData(
             details.Id,
-            details.OfferStatus,
+            details.OfferSubscriptionStatus,
             details.Name,
             details.CompanyName,
             details.Bpn,
@@ -852,7 +852,7 @@ public class OfferService : IOfferService
         var details = await GetOfferSubscriptionDetailsInternal(offerId, subscriptionId, iamUserId, offerTypeId, contactUserRoles, OfferCompanyRole.Subscriber);
         return new SubscriberSubscriptionDetailData(
             details.Id,
-            details.OfferStatus,
+            details.OfferSubscriptionStatus,
             details.Name,
             details.CompanyName,
             details.Contact,

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionDetailData.cs
@@ -26,7 +26,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 /// Detail data for a offer subscription
 /// </summary>
 /// <param name="Id">Id of the Offer</param>
-/// <param name="OfferStatus">Status of the offer</param>
+/// <param name="OfferSubscriptionStatus">Status of the offer subscription</param>
 /// <param name="Name">Name of the Offer</param>
 /// <param name="CompanyName">When called from /provider name of the company subscribing the offer, otherwise the provider company's name</param>
 /// <param name="Bpn">When called from /provider bpn of the company subscribing the offer, otherwise the provider company's bpn</param>
@@ -34,7 +34,7 @@ namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 /// <param name="TechnicalUserData">Information about the technical user</param>
 public record OfferSubscriptionDetailData (
     Guid Id,
-    OfferStatusId OfferStatus,
+    OfferSubscriptionStatusId OfferSubscriptionStatus,
     string? Name,
     string CompanyName,
     string? Bpn,

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -218,7 +218,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 OtherCompany = forProvider ? os.Company : os.Offer!.ProviderCompany,
                 OfferName = os.Offer!.Name,
                 os.OfferId,
-                os.Offer!.OfferStatusId,
+                os.OfferSubscriptionStatusId,
                 os.CompanyServiceAccounts
             })
             .Select(x => new ValueTuple<bool, bool, OfferSubscriptionDetailData>(
@@ -226,7 +226,7 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
                 x.UserCompany!.CompanyUsers.Any(cu => cu.IamUser!.UserEntityId == iamUserId),
                 new OfferSubscriptionDetailData(
                     x.OfferId,
-                    x.OfferStatusId,
+                    x.OfferSubscriptionStatusId,
                     x.OfferName,
                     x.OtherCompany!.Name,
                     x.OtherCompany!.BusinessPartnerNumber,

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -2353,7 +2353,7 @@ public class OfferServiceTests
 
     private void SetupGetSubscriptionDetailForProvider()
     {
-        var data = new OfferSubscriptionDetailData(Guid.NewGuid(), OfferStatusId.ACTIVE, "Test App", "Stark Industry", "BPN123456789",
+        var data = new OfferSubscriptionDetailData(Guid.NewGuid(), OfferSubscriptionStatusId.ACTIVE, "Test App", "Stark Industry", "BPN123456789",
             new[] {"tony@stark.com", "steven@strange.com"}, _fixture.CreateMany<SubscriptionTechnicalUserData>(5));
 
         A.CallTo(() => _userRolesRepository.GetUserRoleIdsUntrackedAsync(A<IDictionary<string, IEnumerable<string>>>.That.Matches(x => x.ContainsKey("ClientTest"))))

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -238,6 +238,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         result.Details.Name.Should().Be("SDE with EDC");
         result.Details.CompanyName.Should().Be("Catena-X");
         result.Details.Contact.Should().ContainSingle().And.Subject.Should().ContainSingle("tobeadded@cx.com");
+        result.Details.OfferSubscriptionStatus.Should().Be(OfferSubscriptionStatusId.ACTIVE);
     }
 
     [Fact]
@@ -255,6 +256,7 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         result.Details.Name.Should().Be("SDE with EDC");
         result.Details.CompanyName.Should().Be("Service Provider");
         result.Details.Contact.Should().ContainSingle().And.Subject.Should().ContainSingle("tobeadded@cx.com");
+        result.Details.OfferSubscriptionStatus.Should().Be(OfferSubscriptionStatusId.ACTIVE);
     }
 
     [Theory]


### PR DESCRIPTION
## Description

the following endpoints now return the offerSubscriptionStatus instead of the offer status

/apps/{appId}/subscription/{subscriptionId}/subscriber
/apps/{appId}/subscription/{subscriptionId}/provider

## Why

The frontend needs to be able to access the offer subscription state id

## Issue

Refs: CPLP-2626

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas

## Corresponding Upstream PR

[PR-31](https://github.com/eclipse-tractusx/portal-backend/pull/31)