### PR TITLE
Feature/cplp 2658 cplp 2648 adding service subscription status

### DIFF
--- a/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -154,17 +154,9 @@ public class AppsBusinessLogic : IAppsBusinessLogic
         await _portalRepositories.SaveAsync().ConfigureAwait(false);
     }
 
-    /// <inheritdoc/>
-    public IAsyncEnumerable<AppWithSubscriptionStatus> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(string iamUserId) =>
-        _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
-            .GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync(iamUserId)
-            .Select(x => new AppWithSubscriptionStatus(
-                x.AppId,
-                x.OfferSubscriptionStatusId,
-                x.Name,
-                x.Provider,
-                x.Image == Guid.Empty ? null : x.Image
-            ));
+    /// <inheritdoc />
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, string iamUserId) =>
+        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, iamUserId, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE);
 
     /// <inheritdoc/>
     public async Task<Pagination.Response<OfferCompanySubscriptionStatusResponse>> GetCompanyProvidedAppSubscriptionStatusesForUserAsync(int page, int size, string iamUserId, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId? statusId, Guid? offerId)

--- a/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/Apps.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -79,8 +79,10 @@ public interface IAppsBusinessLogic
     /// Retrieves subscription statuses of subscribed apps of the provided user's company.
     /// </summary>
     /// <param name="iamUserId">IAM ID of the user to retrieve app subscription statuses for.</param>
-    /// <returns>Async enumerable of user's company's subscribed apps' statuses.</returns>
-    public IAsyncEnumerable<AppWithSubscriptionStatus> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(string iamUserId);
+    /// <param name ="page">page</param>
+    /// <param name ="size">size</param>
+    /// <returns>Returns the details of the subscription status for App user</returns>
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync(int page, int size, string iamUserId);
 
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the provided user's company.

--- a/src/marketplace/Apps.Service/Controllers/AppsController.cs
+++ b/src/marketplace/Apps.Service/Controllers/AppsController.cs
@@ -147,17 +147,18 @@ public class AppsController : ControllerBase
     }
 
     /// <summary>
-    /// Retrieves subscription statuses of subscribed apps of the currently logged in user's company.
+    /// Retrieves subscription statuses of apps.
     /// </summary>
     /// <remarks>Example: GET: /api/apps/subscribed/subscription-status</remarks>
-    /// <response code="200">Returns list of applicable app subscription statuses.</response>
+    /// <response code="200">Returns list of applicable apps subscription statuses.</response>
+    /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
     [HttpGet]
     [Route("subscribed/subscription-status")]
     [Authorize(Roles = "view_subscription")]
-    [ProducesResponseType(typeof(IAsyncEnumerable<(Guid AppId, OfferSubscriptionStatusId AppSubscriptionStatus)>), StatusCodes.Status200OK)]
-    public IAsyncEnumerable<AppWithSubscriptionStatus> GetCompanySubscribedAppSubscriptionStatusesForCurrentUserAsync() =>
-        this.WithIamUserId(userId => _appsBusinessLogic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(userId));
-
+    [ProducesResponseType(typeof(Pagination.Response<OfferSubscriptionStatusDetailData>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedAppSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15) =>
+        this.WithIamUserId(userId => _appsBusinessLogic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(page, size, userId));
     /// <summary>
     /// Retrieves subscription statuses of provided apps of the currently logged in user's company.
     /// </summary>

--- a/src/marketplace/Offers.Library/Models/OfferSubscriptionStatusDetailData.cs
+++ b/src/marketplace/Offers.Library/Models/OfferSubscriptionStatusDetailData.cs
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+using System.Text.Json.Serialization;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
+
+public record OfferSubscriptionStatusDetailData(
+    [property: JsonPropertyName("offerId")] Guid OfferId,
+    [property: JsonPropertyName("name")] string? OfferName,
+    [property: JsonPropertyName("provider")] string Provider,
+    [property: JsonPropertyName("status")] OfferSubscriptionStatusId offerSubscriptionStatusId,
+    [property: JsonPropertyName("image")] Guid? DocumentId);

--- a/src/marketplace/Offers.Library/Service/IOfferService.cs
+++ b/src/marketplace/Offers.Library/Service/IOfferService.cs
@@ -19,6 +19,7 @@
  ********************************************************************************/
 
 using Microsoft.AspNetCore.Http;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
@@ -258,4 +259,15 @@ public interface IOfferService
     /// <param name="contactUserRoles">The roles of the users that will be listed as contact</param>
     /// <returns>Returns the details of the subscription</returns>
     Task<SubscriberSubscriptionDetailData> GetSubscriptionDetailsForSubscriberAsync(Guid offerId, Guid subscriptionId, string iamUserId, OfferTypeId offerTypeId, IDictionary<string, IEnumerable<string>> contactUserRoles);
+
+    /// <summary>
+    /// Gets the information of company Subscribed, Subscription Status for user by OfferType
+    /// </summary>
+    /// <param name="page"></param>
+    /// <param name="size"></param>
+    /// <param name="iamUserId"></param>
+    /// <param name="offerTypeId"></param>
+    /// <param name="documentTypeId"></param>
+    /// <returns>Returns the details of the subscription status for user by OfferType</returns>
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, string iamUserId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId);
 }

--- a/src/marketplace/Offers.Library/Service/OfferService.cs
+++ b/src/marketplace/Offers.Library/Service/OfferService.cs
@@ -21,6 +21,7 @@
 using Microsoft.AspNetCore.Http;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Async;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.Offers.Library.Models;
@@ -897,5 +898,27 @@ public class OfferService : IOfferService
             throw new ConfigurationException($"invalid configuration, at least one of the configured roles does not exist in the database: {string.Join(", ", userRoles.Select(clientRoles => $"client: {clientRoles.Key}, roles: [{string.Join(", ", clientRoles.Value)}]"))}");
         }
         return roleData;
+    }
+    /// <inheritdoc/>
+    public async Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(int page, int size, string iamUserId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId)
+    {
+        async Task<Pagination.Source<OfferSubscriptionStatusDetailData>?> GetCompanySubscribedOfferSubscriptionStatusesData(int skip, int take)
+        {
+            var offerCompanySubscriptionResponse = await _portalRepositories.GetInstance<IOfferSubscriptionsRepository>()
+                .GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(iamUserId, offerTypeId, documentTypeId)(skip, take).ConfigureAwait(false);
+
+            return offerCompanySubscriptionResponse == null
+                ? null
+                : new Pagination.Source<OfferSubscriptionStatusDetailData>(
+                    offerCompanySubscriptionResponse!.Count,
+                    offerCompanySubscriptionResponse.Data.Select(item =>
+                        new OfferSubscriptionStatusDetailData(
+                            item.OfferId,
+                            item.OfferName,
+                            item.Provider,
+                            item.offerSubscriptionStatusId,
+                            item.DocumentId == Guid.Empty ? null : item.DocumentId)));
+        }
+        return await Pagination.CreateResponseAsync(page, size, 15, GetCompanySubscribedOfferSubscriptionStatusesData).ConfigureAwait(false);
     }
 }

--- a/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/IServiceBusinessLogic.cs
@@ -135,4 +135,13 @@ public interface IServiceBusinessLogic
     /// <param name="iamUserId">Id of the iam user</param>
     /// <returns>Returns the details of the subscription</returns>
     Task<SubscriberSubscriptionDetailData> GetSubscriptionDetailForSubscriber(Guid serviceId, Guid subscriptionId, string iamUserId);
+
+    /// <summary>
+    /// Retrieves subscription statuses of subscribed Service of the provided user's company.
+    /// </summary>
+    /// <param name="iamUserId">IAM ID of the user to retrieve Service subscription statuses for.</param>
+    /// <param name ="page">page</param>
+    /// <param name ="size">size</param>
+    /// <returns>Returns the details of the subscription status for Service user</returns>
+    Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, string iamUserId);
 }

--- a/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
+++ b/src/marketplace/Services.Service/BusinessLogic/ServiceBusinessLogic.cs
@@ -209,4 +209,8 @@ public class ServiceBusinessLogic : IServiceBusinessLogic
     /// <inheritdoc />
     public Task<SubscriberSubscriptionDetailData> GetSubscriptionDetailForSubscriber(Guid serviceId, Guid subscriptionId, string iamUserId) =>
         _offerService.GetSubscriptionDetailsForSubscriberAsync(serviceId, subscriptionId, iamUserId, OfferTypeId.SERVICE, _settings.SalesManagerRoles);
+
+    /// <inheritdoc />
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(int page, int size, string iamUserId) =>
+        _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(page, size, iamUserId, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE);
 }

--- a/src/marketplace/Services.Service/Controllers/ServicesController.cs
+++ b/src/marketplace/Services.Service/Controllers/ServicesController.cs
@@ -256,4 +256,18 @@ public class ServicesController : ControllerBase
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     public Task<SubscriberSubscriptionDetailData> GetSubscriptionDetailForSubscriber([FromRoute] Guid serviceId, [FromRoute] Guid subscriptionId) =>
         this.WithIamUserId(iamUserId => _serviceBusinessLogic.GetSubscriptionDetailForSubscriber(serviceId, subscriptionId, iamUserId));
+
+    /// <summary>
+    /// Retrieves subscription statuses of services.
+    /// </summary>
+    /// <remarks>Example: GET: /api/services/subscribed/subscription-status</remarks>
+    /// <response code="200">Returns list of applicable service subscription statuses.</response>
+    /// <response code="400">If sub claim is empty/invalid or user does not exist.</response>
+    [HttpGet]
+    [Route("subscribed/subscription-status")]
+    [Authorize(Roles = "view_subscription")]
+    [ProducesResponseType(typeof(Pagination.Response<OfferSubscriptionStatusDetailData>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public Task<Pagination.Response<OfferSubscriptionStatusDetailData>> GetCompanySubscribedServiceSubscriptionStatusesForUserAsync([FromQuery] int page = 0, [FromQuery] int size = 15) =>
+        this.WithIamUserId(userId => _serviceBusinessLogic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(page, size, userId));
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 BMW Group AG
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
+
+namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
+
+
+public record OfferSubscriptionStatusData(Guid OfferId, string? OfferName, string Provider, OfferSubscriptionStatusId offerSubscriptionStatusId, Guid? DocumentId);

--- a/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Models/OfferSubscriptionStatusData.cs
@@ -22,5 +22,12 @@ using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.PortalEntities.Enums;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess.Models;
 
-
+/// <summary>
+/// Offer Subscriptions Status Data
+/// </summary>
+/// <param name="OfferId">Id of the Offer</param>
+/// <param name="OfferName">Name of the Offer</param>
+/// <param name="Provider">When called from /provider name of the company subscribing the offer, otherwise the provider company's name</param>
+/// <param name="OfferSubscriptionStatus">Status of the offer subscription</param>
+/// <param name="DocumentId">Id of the documents</param>
 public record OfferSubscriptionStatusData(Guid OfferId, string? OfferName, string Provider, OfferSubscriptionStatusId offerSubscriptionStatusId, Guid? DocumentId);

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/IOfferSubscriptionsRepository.cs
@@ -41,12 +41,6 @@ public interface IOfferSubscriptionsRepository
     OfferSubscription CreateOfferSubscription(Guid offerId, Guid companyId, OfferSubscriptionStatusId offerSubscriptionStatusId, Guid requesterId, Guid creatorId);
 
     /// <summary>
-    ///
-    /// </summary>
-    /// <param name="iamUserId"></param>
-    IAsyncEnumerable<(Guid AppId, OfferSubscriptionStatusId OfferSubscriptionStatusId, string? Name, string Provider, Guid Image)> GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync(string iamUserId);
-
-    /// <summary>
     /// Gets the provided offer subscription statuses for the user and given company
     /// </summary>
     /// <param name="iamUserId">Id of user of the Providercompany</param>
@@ -119,4 +113,13 @@ public interface IOfferSubscriptionsRepository
     /// <param name="initialize">Initializes the entity</param>
     /// <param name="setParameters">Updates the fields</param>
     void AttachAndModifyAppSubscriptionDetail(Guid detailId, Guid subscriptionId, Action<AppSubscriptionDetail>? initialize, Action<AppSubscriptionDetail> setParameters);
+
+    /// <summary>
+    /// Gets the Service offer subscription statuses for the user
+    /// </summary>
+    /// <param name="iamUserId">Id of user of the Providercompany</param>
+    /// <param name="offerTypeId">Id of the offer type</param>
+    /// <param name="documentTypeId">Id of the document type</param>
+    /// <returns>Returns a func with skip, take and the pagination of the source</returns>
+    Func<int, int, Task<Pagination.Source<OfferSubscriptionStatusData>?>> GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(string iamUserId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId);
 }

--- a/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
+++ b/src/portalbackend/PortalBackend.DBAccess/Repositories/OfferSubscriptionsRepository.cs
@@ -47,23 +47,6 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
         _context.OfferSubscriptions.Add(new OfferSubscription(Guid.NewGuid(), offerId, companyId, offerSubscriptionStatusId, requesterId, creatorId)).Entity;
 
     /// <inheritdoc />
-    public IAsyncEnumerable<(Guid AppId, OfferSubscriptionStatusId OfferSubscriptionStatusId, string? Name, string Provider, Guid Image)> GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync(string iamUserId) =>
-        _context.OfferSubscriptions.AsNoTracking()
-            .Where(subscription => subscription.Company!.CompanyUsers.Any(user => user.IamUser!.UserEntityId == iamUserId))
-            .Select(s => new ValueTuple<Guid, OfferSubscriptionStatusId, string?, string, Guid>(
-                s.OfferId,
-                s.OfferSubscriptionStatusId,
-                s.Offer!.Name,
-                s.Offer.Provider,
-                s.Offer.Documents
-                    .Where(document =>
-                        document.DocumentTypeId == DocumentTypeId.APP_LEADIMAGE &&
-                        document.DocumentStatusId == DocumentStatusId.LOCKED)
-                    .Select(document => document.Id)
-                    .FirstOrDefault()))
-            .ToAsyncEnumerable();
-
-    /// <inheritdoc />
     public Func<int, int, Task<Pagination.Source<OfferCompanySubscriptionStatusData>?>> GetOwnCompanyProvidedOfferSubscriptionStatusesUntrackedAsync(string iamUserId, OfferTypeId offerTypeId, SubscriptionStatusSorting? sorting, OfferSubscriptionStatusId statusId, Guid? offerId) =>
         (skip, take) => Pagination.CreateSourceQueryAsync(
                 skip,
@@ -263,4 +246,27 @@ public class OfferSubscriptionsRepository : IOfferSubscriptionsRepository
         _context.Attach(appSubscriptionDetail);
         setParameters.Invoke(appSubscriptionDetail);
     }
+
+    /// <inheritdoc />
+    public Func<int, int, Task<Pagination.Source<OfferSubscriptionStatusData>?>> GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(string iamUserId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId) =>
+        (skip, take) => Pagination.CreateSourceQueryAsync(
+                skip,
+                take,
+                _context.OfferSubscriptions
+                    .AsNoTracking()
+                    .Where(os =>
+                        os.Offer!.OfferTypeId == offerTypeId &&
+                        os.Company!.CompanyUsers.Any(user => user.IamUser!.UserEntityId == iamUserId))
+                    .GroupBy(os => os.OfferId),
+                null,
+                os => new OfferSubscriptionStatusData(
+                    os.OfferId,
+                    os.Offer!.Name,
+                    os.Offer.Provider,
+                    os.OfferSubscriptionStatusId,
+                    os.Offer!.Documents
+                    .Where(document => document.DocumentTypeId == documentTypeId
+                        && document.DocumentStatusId == DocumentStatusId.LOCKED)
+                    .Select(document => document.Id).FirstOrDefault()))
+            .SingleOrDefaultAsync();
 }

--- a/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/BusinessLogic/AppBusinessLogicTests.cs
@@ -509,46 +509,42 @@ public class AppBusinessLogicTests
     public async Task GetCompanySubscribedAppSubscriptionStatusesForUserAsync_ReturnsExpected()
     {
         // Arrange
-        var iamUserId = _fixture.Create<string>();
-        var data = _fixture.CreateMany<(Guid AppId, OfferSubscriptionStatusId OfferSubscriptionStatusId, string? Name, string Provider, Guid Image)>(3).ToImmutableArray();
-        A.CallTo(() => _offerSubscriptionRepository.GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync(iamUserId))
-            .Returns(data.ToAsyncEnumerable());
+        var iamUserId = _fixture.Create<Guid>().ToString();
+        var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(5).ToImmutableArray();
+        var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Count(), 1, 0, data.Count()), data);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE))
+            .Returns(pagination);
 
-        var sut = new AppsBusinessLogic(_portalRepositories, null!, null!, null!, _fixture.Create<IOptions<AppsSettings>>(), null!);
+        var sut = new AppsBusinessLogic(_portalRepositories, null!, _offerService, null!, _fixture.Create<IOptions<AppsSettings>>(), _mailingService);
 
         // Act
-        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(iamUserId).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 10, iamUserId).ConfigureAwait(false);
 
         // Assert
-        result.Should().HaveCount(3).And.Satisfy(
-            x => x.AppId == data[0].AppId && x.Name == data[0].Name && x.OfferSubscriptionStatus == data[0].OfferSubscriptionStatusId && x.Provider == data[0].Provider && x.Image == data[0].Image,
-            x => x.AppId == data[1].AppId && x.Name == data[1].Name && x.OfferSubscriptionStatus == data[1].OfferSubscriptionStatusId && x.Provider == data[1].Provider && x.Image == data[1].Image,
-            x => x.AppId == data[2].AppId && x.Name == data[2].Name && x.OfferSubscriptionStatus == data[2].OfferSubscriptionStatusId && x.Provider == data[2].Provider && x.Image == data[2].Image
-        );
+        result.Meta.NumberOfElements.Should().Be(5);
+        result.Content.Should().HaveCount(5);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE)).MustHaveHappenedOnceExactly();
     }
 
     [Fact]
     public async Task GetCompanySubscribedAppSubscriptionStatusesForUserAsync_NullableProperties_ReturnsExpected()
     {
         // Arrange
-        var iamUserId = _fixture.Create<string>();
-        var data = new (Guid AppId, OfferSubscriptionStatusId OfferSubscriptionStatusId, string? Name, string Provider, Guid Image)[] {
-            ( Guid.NewGuid(), OfferSubscriptionStatusId.ACTIVE, null, _fixture.Create<string>(), Guid.Empty )
-        };
+        var iamUserId = _fixture.Create<Guid>().ToString();
+        var paginationResult = (int skip, int take) => Task.FromResult((Pagination.Source<OfferSubscriptionStatusDetailData>?)null!);
+        var response = Pagination.CreateResponseAsync<OfferSubscriptionStatusDetailData>(0, 10, 15, paginationResult);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE))
+            .Returns(response);
 
-        _fixture.CreateMany<(Guid AppId, OfferSubscriptionStatusId OfferSubscriptionStatusId, string? Name, string Provider, Guid Image)>(3).ToImmutableArray();
-        A.CallTo(() => _offerSubscriptionRepository.GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync(iamUserId))
-            .Returns(data.ToAsyncEnumerable());
-
-        var sut = new AppsBusinessLogic(_portalRepositories, null!, null!, null!, _fixture.Create<IOptions<AppsSettings>>(), null!);
+        var sut = new AppsBusinessLogic(_portalRepositories, null!, _offerService, null!, _fixture.Create<IOptions<AppsSettings>>(), _mailingService);
 
         // Act
-        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(iamUserId).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 10, iamUserId).ConfigureAwait(false);
 
         // Assert
-        result.Should().HaveCount(1).And.Satisfy(
-            x => x.AppId == data[0].AppId && x.Name == null && x.Image == null
-        );
+        result.Meta.NumberOfElements.Should().Be(0);
+        result.Content.Should().BeEmpty();
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE)).MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
+++ b/tests/marketplace/Apps.Service.Tests/Controllers/AppsControllerTests.cs
@@ -156,16 +156,17 @@ public class AppsControllerTests
     public async Task GetCompanySubscribedAppSubscriptionStatusesForCurrentUserAsync_ReturnsExpectedCount()
     {
         //Arrange
-        var data = _fixture.CreateMany<AppWithSubscriptionStatus>(3).ToImmutableArray();
-        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(A<string>._))
-            .Returns(data.ToAsyncEnumerable());
+        var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(3).ToImmutableArray();
+        var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Count(), 1, 0, data.Count()), data);
+        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<string>._))
+            .Returns(pagination);
 
         //Act
-        var result = await this._controller.GetCompanySubscribedAppSubscriptionStatusesForCurrentUserAsync().ToListAsync().ConfigureAwait(false);
+        var result = await this._controller.GetCompanySubscribedAppSubscriptionStatusesForUserAsync().ConfigureAwait(false);
 
         //Assert
-        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(IamUserId)).MustHaveHappenedOnceExactly();
-        result.Should().HaveCount(3).And.ContainInOrder(data);
+        A.CallTo(() => _logic.GetCompanySubscribedAppSubscriptionStatusesForUserAsync(0, 15, IamUserId)).MustHaveHappenedOnceExactly();
+        result.Content.Should().HaveCount(3).And.ContainInOrder(data);
     }
 
     #endregion

--- a/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
+++ b/tests/marketplace/Offers.Library.Tests/Service/OfferServiceTests.cs
@@ -19,6 +19,7 @@
  ********************************************************************************/
 
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Mailing.SendMail;
 using Org.Eclipse.TractusX.Portal.Backend.Notifications.Library;
 using Org.Eclipse.TractusX.Portal.Backend.PortalBackend.DBAccess;
@@ -2235,6 +2236,37 @@ public class OfferServiceTests
         result.Customer.Should().Be("Stark Industry");
         result.Contact.Should().HaveCount(2);
         result.TechnicalUserData.Should().HaveCount(5);
+    }
+
+    #endregion
+
+    #region  GetCompanySubscribedOfferSubscriptionStatusesForUser
+
+    [Theory]
+    [InlineData(OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE)]
+    [InlineData(OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE)]
+    public async Task GetCompanySubscribedOfferSubscriptionStatusesForUserAsync_ReturnsExpected(OfferTypeId offerTypeId, DocumentTypeId documentTypeId)
+    {
+        // Arrange
+        var iamUserId = _fixture.Create<Guid>().ToString();
+        var data = _fixture.CreateMany<OfferSubscriptionStatusData>(5).ToImmutableArray();
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(iamUserId, offerTypeId, documentTypeId))
+            .Returns((skip, take) => Task.FromResult(new Pagination.Source<OfferSubscriptionStatusData>(data.Length, data.Skip(skip).Take(take)))!);
+
+        // Act
+        var result = await _sut.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, offerTypeId, documentTypeId).ConfigureAwait(false);
+
+        // Assert
+        result.Meta.NumberOfElements.Should().Be(5);
+        result.Content.Should().HaveCount(5).And.Satisfy(
+            x => x.OfferId == data[0].OfferId && x.OfferName == data[0].OfferName && x.Provider == data[0].Provider && x.offerSubscriptionStatusId == data[0].offerSubscriptionStatusId && x.DocumentId == data[0].DocumentId,
+            x => x.OfferId == data[1].OfferId && x.OfferName == data[1].OfferName && x.Provider == data[1].Provider && x.offerSubscriptionStatusId == data[1].offerSubscriptionStatusId && x.DocumentId == data[1].DocumentId,
+            x => x.OfferId == data[2].OfferId && x.OfferName == data[2].OfferName && x.Provider == data[2].Provider && x.offerSubscriptionStatusId == data[2].offerSubscriptionStatusId && x.DocumentId == data[2].DocumentId,
+            x => x.OfferId == data[3].OfferId && x.OfferName == data[3].OfferName && x.Provider == data[3].Provider && x.offerSubscriptionStatusId == data[3].offerSubscriptionStatusId && x.DocumentId == data[3].DocumentId,
+            x => x.OfferId == data[4].OfferId && x.OfferName == data[4].OfferName && x.Provider == data[4].Provider && x.offerSubscriptionStatusId == data[4].offerSubscriptionStatusId && x.DocumentId == data[4].DocumentId
+        );
+        A.CallTo(() => _offerSubscriptionsRepository.GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(iamUserId, offerTypeId, documentTypeId))
+            .MustHaveHappenedOnceExactly();
     }
 
     #endregion

--- a/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
+++ b/tests/marketplace/Services.Service.Tests/BusinessLogic/ServiceBusinessLogicTests.cs
@@ -638,6 +638,52 @@ public class ServiceBusinessLogicTests
 
     #endregion
 
+    #region GetCompanySubscribedServiceSubscriptionStatusesForUserAsync
+
+    [Fact]
+    public async Task GetCompanySubscribedServiceSubscriptionStatusesForUserAsync_ReturnsExpected()
+    {
+        // Arrange
+        var iamUserId = _fixture.Create<Guid>().ToString();
+        var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(5).ToImmutableArray();
+        var paginationResponse = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Count(), 1, 0, data.Count()), data);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE))
+            .Returns(paginationResponse);
+
+        var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, Options.Create(new ServiceSettings()));
+
+        // Act
+        var result = await sut.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 10, iamUserId).ConfigureAwait(false);
+
+        // Assert
+        result.Meta.NumberOfElements.Should().Be(5);
+        result.Content.Should().HaveCount(5);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task GetCompanySubscribedServiceSubscriptionStatusesForUserAsync_NullableProperties_ReturnsExpected()
+    {
+        // Arrange
+        var iamUserId = _fixture.Create<Guid>().ToString();
+        var paginationResult = (int skip, int take) => Task.FromResult((Pagination.Source<OfferSubscriptionStatusDetailData>?)null!);
+        var response = Pagination.CreateResponseAsync<OfferSubscriptionStatusDetailData>(0, 10, 15, paginationResult);
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE))
+            .Returns(response);
+
+        var sut = new ServiceBusinessLogic(null!, _offerService, null!, null!, Options.Create(new ServiceSettings()));
+
+        // Act
+        var result = await sut.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 10, iamUserId).ConfigureAwait(false);
+
+        // Assert
+        result.Meta.NumberOfElements.Should().Be(0);
+        result.Content.Should().BeEmpty();
+        A.CallTo(() => _offerService.GetCompanySubscribedOfferSubscriptionStatusesForUserAsync(0, 10, iamUserId, OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE)).MustHaveHappenedOnceExactly();
+    }
+
+    #endregion
+
     #region Setup
 
     private void SetupPagination(int count = 5)

--- a/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
+++ b/tests/marketplace/Services.Service.Tests/Controllers/ServiceControllerTest.cs
@@ -32,6 +32,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Services.Service.Controllers;
 using Org.Eclipse.TractusX.Portal.Backend.Services.Service.ViewModels;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared;
 using Org.Eclipse.TractusX.Portal.Backend.Tests.Shared.Extensions;
+using System.Collections.Immutable;
 using Xunit;
 
 namespace Org.Eclipse.TractusX.Portal.Backend.Services.Service.Tests.Controllers;
@@ -274,4 +275,25 @@ public class ServiceControllerTest
         A.CallTo(() => _logic.GetSubscriptionDetailForSubscriber(serviceId, subscriptionId, IamUserId)).MustHaveHappenedOnceExactly();
         result.Should().Be(data);
     }
+
+    #region GetCompanySubscribedServiceSubscriptionStatusesForCurrentUserAsync
+
+    [Fact]
+    public async Task GetCompanySubscribedServiceSubscriptionStatusesForCurrentUserAsync_ReturnsExpectedCount()
+    {
+        //Arrange
+        var data = _fixture.CreateMany<OfferSubscriptionStatusDetailData>(3).ToImmutableArray();
+        var pagination = new Pagination.Response<OfferSubscriptionStatusDetailData>(new Pagination.Metadata(data.Count(), 1, 0, data.Count()), data);
+        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(A<int>._, A<int>._, A<string>._))
+            .Returns(pagination);
+
+        //Act
+        var result = await this._controller.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync().ConfigureAwait(false);
+
+        //Assert
+        A.CallTo(() => _logic.GetCompanySubscribedServiceSubscriptionStatusesForUserAsync(0, 15, IamUserId)).MustHaveHappenedOnceExactly();
+        result.Content.Should().HaveCount(3).And.ContainInOrder(data);
+    }
+
+    #endregion
 }

--- a/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
+++ b/tests/portalbackend/PortalBackend.DBAccess.Tests/OfferSubscriptionRepositoryTest.cs
@@ -195,30 +195,6 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         result.OfferName.Should().Be("Trace-X");
     }
 
-    [Fact]
-    public async Task GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync_WithExistingData_ReturnsExpectedResult()
-    {
-        // Arrange
-        var (sut, _) = await CreateSut().ConfigureAwait(false);
-
-        // Act
-        var result = await sut.GetOwnCompanySubscribedAppSubscriptionStatusesUntrackedAsync("502dabcf-01c7-47d9-a88e-0be4279097b5").ToListAsync().ConfigureAwait(false);
-
-        // Assert
-        result.Should().HaveCount(2).And.Satisfy(
-            x => x.AppId == new Guid("a16e73b9-5277-4b69-9f8d-3b227495dfea") &&
-                x.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
-                x.Name == "SDE with EDC" &&
-                x.Provider == "Service Provider" &&
-                x.Image == Guid.Empty,
-            x => x.AppId == new Guid("ac1cf001-7fbc-1f2f-817f-bce0572c0007") &&
-                x.OfferSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
-                x.Name == "Trace-X" &&
-                x.Provider == "Catena-X" &&
-                x.Image == new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b1")
-        );
-    }
-
     #endregion
 
     #region GetSubscriptionDetailForProviderAsync
@@ -399,6 +375,45 @@ public class OfferSubscriptionRepositoryTest : IAssemblyFixture<TestDbFixture>
         // Assert
         var changeTracker = context.ChangeTracker;
         changeTracker.HasChanges().Should().BeFalse();
+    }
+
+    #endregion
+
+    #region  GetOwnCompanySubscribedOfferSubscriptionStatuse
+
+    [Theory]
+    [InlineData("502dabcf-01c7-47d9-a88e-0be4279097b5", OfferTypeId.APP, DocumentTypeId.APP_LEADIMAGE)]
+    [InlineData("502dabcf-01c7-47d9-a88e-0be4279097b5", OfferTypeId.SERVICE, DocumentTypeId.SERVICE_LEADIMAGE)]
+    public async Task GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync_ReturnsExpected(string iamUserId, OfferTypeId offerTypeId, DocumentTypeId documentTypeId)
+    {
+        // Arrange
+        var (sut, _) = await CreateSut().ConfigureAwait(false);
+
+        // Act
+        var result = await sut.GetOwnCompanySubscribedOfferSubscriptionStatusesUntrackedAsync(iamUserId, offerTypeId, documentTypeId)(0, 15).ConfigureAwait(false);
+
+        // Assert
+        result.Should().NotBeNull();
+        if (offerTypeId == OfferTypeId.APP)
+        {
+            result!.Data.Should().HaveCount(1).And.Satisfy(
+                x => x.OfferId == new Guid("ac1cf001-7fbc-1f2f-817f-bce0572c0007") &&
+                    x.offerSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
+                    x.OfferName == "Trace-X" &&
+                    x.Provider == "Catena-X" &&
+                    x.DocumentId == new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b1")
+            );
+        }
+        else
+        {
+            result!.Data.Should().HaveCount(1).And.Satisfy(
+                x => x.OfferId == new Guid("a16e73b9-5277-4b69-9f8d-3b227495dfea") &&
+                    x.offerSubscriptionStatusId == OfferSubscriptionStatusId.ACTIVE &&
+                    x.OfferName == "SDE with EDC" &&
+                    x.Provider == "Service Provider" &&
+                    x.DocumentId == Guid.Empty
+            );
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Description

added endpoint to get the subscription status for Service and moved logic to OfferService

## Why

to returns list of applicable apps and service subscription statuses for own companyusers.

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
