### PR TITLE
chore(dependencies-check): change to preview .NET 9

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0']
+        # change to preview .NET 9 until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8
+        dotnet-version: ['9.0']
 
     steps:
   
@@ -46,6 +47,8 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+          # change to preview .NET 9 until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8
+          dotnet-quality: 'preview'
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -44,7 +44,7 @@ jobs:
           java-version: '17'
 
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
           # change to preview .NET 9 until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8


### PR DESCRIPTION
## Description

change to preview .NET 9 for dependencies-check until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8

example run https://github.com/eclipse-tractusx/portal-backend/actions/runs/8376785017/job/22937256825

## Why

https://github.com/eclipse-tractusx/portal-backend/pull/533

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
